### PR TITLE
chore(all services): Check for incorrect url and credentials

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -132,3 +132,10 @@ func CreateFormPartName(template string, keyName string, keyValue string) string
 	toBeReplaced := "{" + keyName + "}"
 	return strings.Replace(template, toBeReplaced, keyValue, 1)
 }
+
+// HasBadFirstOrLastChar checks if the string starts with `{` or `"`
+// or ends with `}` or `"`
+func HasBadFirstOrLastChar(str string) bool {
+	return strings.HasPrefix(str, "{") || strings.HasPrefix(str, "\"") ||
+		strings.HasSuffix(str, "}") || strings.HasSuffix(str, "\"")
+}

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -97,3 +97,11 @@ func TestCreateFormPartName(t *testing.T) {
 	assert.Equal(t, "this_is_a_test", CreateFormPartName("this_is_{word}_test", "word", "a"))
 	assert.Equal(t, "this_is_not_a_test", CreateFormPartName("this_is_{word}_test", "word", "not_a"))
 }
+
+func TestHasBadFirstOrLastChar(t *testing.T) {
+	assert.Equal(t, true, HasBadFirstOrLastChar("{hello}"))
+	assert.Equal(t, true, HasBadFirstOrLastChar("hello}"))
+	assert.Equal(t, true, HasBadFirstOrLastChar("\"hello"))
+	assert.Equal(t, true, HasBadFirstOrLastChar("hello\""))
+	assert.Equal(t, false, HasBadFirstOrLastChar("hello"))
+}

--- a/core/watson_test.go
+++ b/core/watson_test.go
@@ -37,6 +37,26 @@ func TestRequestResponseAsJSON(t *testing.T) {
 	assert.Equal(t, "wonder woman", *detailedResponse.Result.(*Foo).Name)
 }
 
+func TestIncorrectCreds(t *testing.T) {
+	options := &ServiceOptions{
+		URL:      "xxx",
+		Username: "{yyy}",
+		Password: "zzz",
+	}
+	_, serviceErr := NewWatsonService(options, "watson")
+	assert.Equal(t, "The username shouldn't start or end with curly brackets or quotes. Be sure to remove any {} and \" characters surrounding your username", serviceErr.Error())
+}
+
+func TestIncorrectURL(t *testing.T) {
+	options := &ServiceOptions{
+		URL:      "{xxx}",
+		Username: "yyy",
+		Password: "zzz",
+	}
+	_, serviceErr := NewWatsonService(options, "watson")
+	assert.Equal(t, "The URL shouldn't start or end with curly brackets or quotes. Be sure to remove any {} and \" characters surrounding your URL", serviceErr.Error())
+}
+
 func TestDisableSSLverification(t *testing.T) {
 	options := &ServiceOptions{
 		URL:      "test.com",


### PR DESCRIPTION
Users have had issues with authenticating services if they mistakenly add { or " into different fields as described in documentation. We should detect these in the first character of the username, password, apikey and service url and throw an error.