### PR TITLE
feat(Credential Initialization): Load credentials from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,47 @@ Watson services are migrating to token-based Identity and Access Management (IAM
 ### Getting credentials
 To find out which authentication to use, view the service credentials. You find the service credentials for authentication the same way for all Watson services:
 
-1. Go to the IBM Cloud [Dashboard](https://console.bluemix.net/dashboard/apps?category=ai) page.
-1. Either click an existing Watson service instance or click [**Create resource > AI**](https://console.bluemix.net/catalog/?category=ai) and create a service instance.
-1. Copy the `url` and either `apikey` or `username` and `password`. Click **Show** if the credentials are masked.
+1. Go to the IBM Cloud [Dashboard](https://cloud.ibm.com/) page.
+1. Either click an existing Watson service instance in your [resource list](https://cloud.ibm.com/resources) or click [**Create resource > AI**](https://cloud.ibm.com/catalog?category=ai) and create a service instance.
+1. Click on the **Manage** item in the left nav bar of your service instance.
+
+On this page, you should be able to see your credentials for accessing your service instance.
+
+### Supplying credentials
+
+There are two ways to supply the credentials you found above to the SDK for authentication.
+
+#### Credential file (easier!)
+
+With a credential file, you just need to put the file in the right place and the SDK will do the work of parsing and authenticating. You can get this file by clicking the **Download** button for the credentials in the **Manage** tab of your service instance.
+
+The file downloaded will be called `ibm-credentials.env`. This is the name the SDK will search for and **must** be preserved unless you want to configure the file path (more on that later). The SDK will look for your `ibm-credentials.env` file in the following places (in order):
+
+- Your system's home directory
+- The top-level directory of the project you're using the SDK in
+
+As long as you set that up correctly, you don't have to worry about setting any authentication options in your code. So, for example, if you created and downloaded the credential file for your Discovery instance, you just need to do the following:
+
+```go
+discovery, discoveryErr := NewDiscoveryV1(&DiscoveryV1Options{
+	Version:   "2018-03-05",
+})
+```
+
+And that's it!
+
+If you're using more than one service at a time in your code and get two different `ibm-credentials.env` files, just put the contents together in one `ibm-credentials.env` file and the SDK will handle assigning credentials to their appropriate services.
+
+If you would like to configure the location/name of your credential file, you can set an environment variable called `IBM_CREDENTIALS_FILE`. **This will take precedence over the locations specified above.** Here's how you can do that:
+
+```bash
+export IBM_CREDENTIALS_FILE="<path>"
+```
+
+where `<path>` is something like `/home/user/Downloads/<file_name>.env`.
+
+#### Manually
+If you'd prefer to set authentication values manually in your code, the SDK supports that as well. The way you'll do this depends on what type of credentials your service instance gives you.
 
 ### IAM
 IBM Cloud is migrating to token-based Identity and Access Management (IAM) authentication. IAM authentication uses a service API key to get an access token that is passed with the call. Access tokens are valid for approximately one hour and must be regenerated.

--- a/assistantv1/assistant_v1.go
+++ b/assistantv1/assistant_v1.go
@@ -58,7 +58,7 @@ func NewAssistantV1(options *AssistantV1Options) (*AssistantV1, error) {
 		IAMAccessToken: options.IAMAccessToken,
 		IAMURL:         options.IAMURL,
 	}
-	service, serviceErr := core.NewWatsonService(serviceOptions, "conversation")
+	service, serviceErr := core.NewWatsonService(serviceOptions, "conversation", "Assistant")
 	if serviceErr != nil {
 		return nil, serviceErr
 	}

--- a/assistantv2/assistant_v2.go
+++ b/assistantv2/assistant_v2.go
@@ -56,7 +56,7 @@ func NewAssistantV2(options *AssistantV2Options) (*AssistantV2, error) {
 		IAMAccessToken: options.IAMAccessToken,
 		IAMURL:         options.IAMURL,
 	}
-	service, serviceErr := core.NewWatsonService(serviceOptions, "conversation")
+	service, serviceErr := core.NewWatsonService(serviceOptions, "conversation", "Assistant")
 	if serviceErr != nil {
 		return nil, serviceErr
 	}

--- a/comparecomplyv1/compare_comply_v1.go
+++ b/comparecomplyv1/compare_comply_v1.go
@@ -55,7 +55,7 @@ func NewCompareComplyV1(options *CompareComplyV1Options) (*CompareComplyV1, erro
 		IAMAccessToken: options.IAMAccessToken,
 		IAMURL:         options.IAMURL,
 	}
-	service, serviceErr := core.NewWatsonService(serviceOptions, "compare-comply")
+	service, serviceErr := core.NewWatsonService(serviceOptions, "compare-comply", "Compare Comply")
 	if serviceErr != nil {
 		return nil, serviceErr
 	}

--- a/core/utils.go
+++ b/core/utils.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strings"
 
 	validator "gopkg.in/go-playground/validator.v9"
@@ -138,4 +140,16 @@ func CreateFormPartName(template string, keyName string, keyValue string) string
 func HasBadFirstOrLastChar(str string) bool {
 	return strings.HasPrefix(str, "{") || strings.HasPrefix(str, "\"") ||
 		strings.HasSuffix(str, "}") || strings.HasSuffix(str, "\"")
+}
+
+// UserHomeDir returns the user home directory
+func UserHomeDir() string {
+	if runtime.GOOS == "windows" {
+		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		if home == "" {
+			home = os.Getenv("USERPROFILE")
+		}
+		return home
+	}
+	return os.Getenv("HOME")
 }

--- a/core/watson_test.go
+++ b/core/watson_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +34,7 @@ func TestRequestResponseAsJSON(t *testing.T) {
 		Username: "xxx",
 		Password: "yyy",
 	}
-	service, _ := NewWatsonService(options, "watson")
+	service, _ := NewWatsonService(options, "watson", "watson")
 	detailedResponse, _ := service.Request(req, new(Foo))
 	assert.Equal(t, "wonder woman", *detailedResponse.Result.(*Foo).Name)
 }
@@ -43,7 +45,7 @@ func TestIncorrectCreds(t *testing.T) {
 		Username: "{yyy}",
 		Password: "zzz",
 	}
-	_, serviceErr := NewWatsonService(options, "watson")
+	_, serviceErr := NewWatsonService(options, "watson", "watson")
 	assert.Equal(t, "The username shouldn't start or end with curly brackets or quotes. Be sure to remove any {} and \" characters surrounding your username", serviceErr.Error())
 }
 
@@ -53,7 +55,7 @@ func TestIncorrectURL(t *testing.T) {
 		Username: "yyy",
 		Password: "zzz",
 	}
-	_, serviceErr := NewWatsonService(options, "watson")
+	_, serviceErr := NewWatsonService(options, "watson", "watson")
 	assert.Equal(t, "The URL shouldn't start or end with curly brackets or quotes. Be sure to remove any {} and \" characters surrounding your URL", serviceErr.Error())
 }
 
@@ -63,7 +65,7 @@ func TestDisableSSLverification(t *testing.T) {
 		Username: "xxx",
 		Password: "yyy",
 	}
-	service, _ := NewWatsonService(options, "watson")
+	service, _ := NewWatsonService(options, "watson", "watson")
 	assert.Nil(t, service.Client.Transport)
 	service.DisableSSLVerification()
 	assert.NotNil(t, service.Client.Transport)
@@ -87,7 +89,21 @@ func TestAuthentication(t *testing.T) {
 		Username: "xxx",
 		Password: "yyy",
 	}
-	service, _ := NewWatsonService(options, "watson")
+	service, _ := NewWatsonService(options, "watson", "watson")
 
 	service.Request(req, new(Foo))
+}
+
+func TestLoadingFromCredentialFile(t *testing.T) {
+	pwd, _ := os.Getwd()
+	credentialFilePath := path.Join(pwd, "/../resources/ibm-credentials.env")
+	os.Setenv("IBM_CREDENTIALS_FILE", credentialFilePath)
+	options := &ServiceOptions{}
+	service, _ := NewWatsonService(options, "watson", "watson")
+	assert.Equal(t, service.Options.IAMApiKey, "5678efgh")
+	os.Unsetenv("IBM_CREDENTIALS_FILE")
+
+	options2 := &ServiceOptions{IAMApiKey: "xxx"}
+	service2, _ := NewWatsonService(options2, "watson", "watson")
+	assert.Equal(t, service2.Options.IAMApiKey, "xxx")
 }

--- a/discoveryv1/discovery_v1.go
+++ b/discoveryv1/discovery_v1.go
@@ -62,7 +62,7 @@ func NewDiscoveryV1(options *DiscoveryV1Options) (*DiscoveryV1, error) {
 		IAMAccessToken: options.IAMAccessToken,
 		IAMURL:         options.IAMURL,
 	}
-	service, serviceErr := core.NewWatsonService(serviceOptions, "discovery")
+	service, serviceErr := core.NewWatsonService(serviceOptions, "discovery", "Discovery")
 	if serviceErr != nil {
 		return nil, serviceErr
 	}

--- a/languagetranslatorv3/language_translator_v3.go
+++ b/languagetranslatorv3/language_translator_v3.go
@@ -60,7 +60,7 @@ func NewLanguageTranslatorV3(options *LanguageTranslatorV3Options) (*LanguageTra
 		IAMAccessToken: options.IAMAccessToken,
 		IAMURL:         options.IAMURL,
 	}
-	service, serviceErr := core.NewWatsonService(serviceOptions, "language_translator")
+	service, serviceErr := core.NewWatsonService(serviceOptions, "language_translator", "Language Translator")
 	if serviceErr != nil {
 		return nil, serviceErr
 	}

--- a/naturallanguageclassifierv1/natural_language_classifier_v1.go
+++ b/naturallanguageclassifierv1/natural_language_classifier_v1.go
@@ -57,7 +57,7 @@ func NewNaturalLanguageClassifierV1(options *NaturalLanguageClassifierV1Options)
 		IAMAccessToken: options.IAMAccessToken,
 		IAMURL:         options.IAMURL,
 	}
-	service, serviceErr := core.NewWatsonService(serviceOptions, "natural_language_classifier")
+	service, serviceErr := core.NewWatsonService(serviceOptions, "natural_language_classifier", "Natural Language Classifier")
 	if serviceErr != nil {
 		return nil, serviceErr
 	}

--- a/naturallanguageunderstandingv1/natural_language_understanding_v1.go
+++ b/naturallanguageunderstandingv1/natural_language_understanding_v1.go
@@ -62,7 +62,7 @@ func NewNaturalLanguageUnderstandingV1(options *NaturalLanguageUnderstandingV1Op
 		IAMAccessToken: options.IAMAccessToken,
 		IAMURL:         options.IAMURL,
 	}
-	service, serviceErr := core.NewWatsonService(serviceOptions, "natural-language-understanding")
+	service, serviceErr := core.NewWatsonService(serviceOptions, "natural-language-understanding", "Natural Language Understanding")
 	if serviceErr != nil {
 		return nil, serviceErr
 	}

--- a/personalityinsightsv3/personality_insights_v3.go
+++ b/personalityinsightsv3/personality_insights_v3.go
@@ -71,7 +71,7 @@ func NewPersonalityInsightsV3(options *PersonalityInsightsV3Options) (*Personali
 		IAMAccessToken: options.IAMAccessToken,
 		IAMURL:         options.IAMURL,
 	}
-	service, serviceErr := core.NewWatsonService(serviceOptions, "personality_insights")
+	service, serviceErr := core.NewWatsonService(serviceOptions, "personality_insights", "Personality Insights")
 	if serviceErr != nil {
 		return nil, serviceErr
 	}

--- a/resources/ibm-credentials.env
+++ b/resources/ibm-credentials.env
@@ -1,0 +1,4 @@
+VISUAL_RECOGNITION_APIKEY=1234abcd
+VISUAL_RECOGNITION_URL=https://stgwat-us-south-mzr-cruiser6.us-south.containers.mybluemix.net/visual-recognition/api
+WATSON_APIKEY=5678efgh
+WATSON_URL=https://gateway-s.watsonplatform.net/watson/api

--- a/speechtotextv1/speech_to_text_v1.go
+++ b/speechtotextv1/speech_to_text_v1.go
@@ -73,7 +73,7 @@ func NewSpeechToTextV1(options *SpeechToTextV1Options) (*SpeechToTextV1, error) 
 		IAMAccessToken: options.IAMAccessToken,
 		IAMURL:         options.IAMURL,
 	}
-	service, serviceErr := core.NewWatsonService(serviceOptions, "speech_to_text")
+	service, serviceErr := core.NewWatsonService(serviceOptions, "speech_to_text", "Speech to Text")
 	if serviceErr != nil {
 		return nil, serviceErr
 	}

--- a/texttospeechv1/text_to_speech_v1.go
+++ b/texttospeechv1/text_to_speech_v1.go
@@ -69,7 +69,7 @@ func NewTextToSpeechV1(options *TextToSpeechV1Options) (*TextToSpeechV1, error) 
 		IAMAccessToken: options.IAMAccessToken,
 		IAMURL:         options.IAMURL,
 	}
-	service, serviceErr := core.NewWatsonService(serviceOptions, "text_to_speech")
+	service, serviceErr := core.NewWatsonService(serviceOptions, "text_to_speech", "Text to Speech")
 	if serviceErr != nil {
 		return nil, serviceErr
 	}

--- a/toneanalyzerv3/tone_analyzer_v3.go
+++ b/toneanalyzerv3/tone_analyzer_v3.go
@@ -64,7 +64,7 @@ func NewToneAnalyzerV3(options *ToneAnalyzerV3Options) (*ToneAnalyzerV3, error) 
 		IAMAccessToken: options.IAMAccessToken,
 		IAMURL:         options.IAMURL,
 	}
-	service, serviceErr := core.NewWatsonService(serviceOptions, "tone_analyzer")
+	service, serviceErr := core.NewWatsonService(serviceOptions, "tone_analyzer", "Tone Analyzer")
 	if serviceErr != nil {
 		return nil, serviceErr
 	}

--- a/visualrecognitionv3/visual_recognition_v3.go
+++ b/visualrecognitionv3/visual_recognition_v3.go
@@ -58,7 +58,7 @@ func NewVisualRecognitionV3(options *VisualRecognitionV3Options) (*VisualRecogni
 		IAMAccessToken: options.IAMAccessToken,
 		IAMURL:         options.IAMURL,
 	}
-	service, serviceErr := core.NewWatsonService(serviceOptions, "watson_vision_combined")
+	service, serviceErr := core.NewWatsonService(serviceOptions, "watson_vision_combined", "Visual Recognition")
 	if serviceErr != nil {
 		return nil, serviceErr
 	}


### PR DESCRIPTION
related to https://github.ibm.com/Watson/developer-experience/issues/5981
Capability to load credentials from file with the order being:

* The file path specified by an environment variable called IBM_CREDENTIALS_FILE
* The user's home directory
Mac/Linux: $HOME
Windows: %HOMEDRIVE%%HOMEPATH% or %USERPROFILE%
* The top-level of the project directory