### PR TITLE
feat(content-type): Request builder to not rely on content type

### DIFF
--- a/core/request_builder.go
+++ b/core/request_builder.go
@@ -243,37 +243,32 @@ func (requestBuilder *RequestBuilder) Build() (*http.Request, error) {
 	return req, nil
 }
 
-// SetBodyContent - sets the body content from one of three different sources, based on the content type
+// SetBodyContent - sets the body content from one of three different sources
 func (requestBuilder *RequestBuilder) SetBodyContent(contentType string, jsonContent interface{}, jsonPatchContent interface{},
 	nonJSONContent interface{}) (*RequestBuilder, error) {
-	if contentType != "" {
-		if IsJSONMimeType(contentType) {
-			if builder, err := requestBuilder.SetBodyContentJSON(jsonContent); err != nil {
-				return builder, err
-			}
-		} else if IsJSONPatchMimeType(contentType) {
-			if builder, err := requestBuilder.SetBodyContentJSON(jsonPatchContent); err != nil {
-				return builder, err
-			}
-		} else {
-			// Set the non-JSON body content based on the type of value passed in,
-			// which should be a "string", "*string" or an "io.Reader"
-			if str, ok := nonJSONContent.(string); ok {
-				requestBuilder.SetBodyContentString(str)
-			} else if strPtr, ok := nonJSONContent.(*string); ok {
-				requestBuilder.SetBodyContentString(*strPtr)
-			} else if stream, ok := nonJSONContent.(io.Reader); ok {
-				requestBuilder.SetBodyContentStream(stream)
-			} else if stream, ok := nonJSONContent.(*io.ReadCloser); ok {
-				requestBuilder.SetBodyContentStream(*stream)
-			} else {
-				return requestBuilder, fmt.Errorf("Invalid type for non-JSON body content: %s",
-					reflect.TypeOf(nonJSONContent).String())
-			}
+	if jsonContent != nil {
+		if builder, err := requestBuilder.SetBodyContentJSON(jsonContent); err != nil {
+			return builder, err
+		}
+	} else if jsonPatchContent != nil {
+		if builder, err := requestBuilder.SetBodyContentJSON(jsonPatchContent); err != nil {
+			return builder, err
 		}
 	} else {
-		return requestBuilder, fmt.Errorf("Content-Type cant be empty")
+		// Set the non-JSON body content based on the type of value passed in,
+		// which should be a "string", "*string" or an "io.Reader"
+		if str, ok := nonJSONContent.(string); ok {
+			requestBuilder.SetBodyContentString(str)
+		} else if strPtr, ok := nonJSONContent.(*string); ok {
+			requestBuilder.SetBodyContentString(*strPtr)
+		} else if stream, ok := nonJSONContent.(io.Reader); ok {
+			requestBuilder.SetBodyContentStream(stream)
+		} else if stream, ok := nonJSONContent.(*io.ReadCloser); ok {
+			requestBuilder.SetBodyContentStream(*stream)
+		} else {
+			return requestBuilder, fmt.Errorf("Invalid type for non-JSON body content: %s",
+				reflect.TypeOf(nonJSONContent).String())
+		}
 	}
-
 	return requestBuilder, nil
 }

--- a/examples/personalityinsightsv3/personality_insights_v3.go
+++ b/examples/personalityinsightsv3/personality_insights_v3.go
@@ -40,7 +40,8 @@ func main() {
 
 	// Create a new ProfileOptions for ContentType "text/plain"
 	profileOptions := service.
-		NewProfileOptions(personalityinsightsv3.ProfileOptions_ContentType_TextPlain)
+		NewProfileOptions().
+		SetContentType(personalityinsightsv3.ProfileOptions_ContentType_TextPlain)
 	profileOptions.SetBody(string(file))
 	profileOptions.ContentLanguage = core.StringPtr("en")
 	profileOptions.AcceptLanguage = core.StringPtr("en")

--- a/examples/speechtotextv1/speech_to_text_v1.go
+++ b/examples/speechtotextv1/speech_to_text_v1.go
@@ -33,8 +33,8 @@ func main() {
 
 	// Create a new RecognizeOptions for ContentType "audio/mp3"
 	recognizeOptions := service.
-		NewRecognizeOptions(audio,
-			speechtotextv1.RecognizeOptions_ContentType_AudioMp3)
+		NewRecognizeOptions(audio).
+		SetContentType(speechtotextv1.RecognizeOptions_ContentType_AudioMp3)
 
 	// Call the speechToText Recognize method
 	response, responseErr := service.Recognize(recognizeOptions)

--- a/examples/toneanalyzerv3/tone_analyzer_v3.go
+++ b/examples/toneanalyzerv3/tone_analyzer_v3.go
@@ -60,8 +60,9 @@ func main() {
 	/* TONE */
 
 	// Call the toneAnalyzer Tone method
-	toneOptions := service.NewToneOptions(toneanalyzerv3.ToneOptions_ContentType_TextPlain).
-		SetBody("I am very happy. It is a good day")
+	toneOptions := service.NewToneOptions().
+		SetBody("I am very happy. It is a good day").
+		SetContentType(toneanalyzerv3.ToneOptions_ContentType_TextPlain)
 	response, responseErr = service.Tone(toneOptions)
 
 	if responseErr != nil {
@@ -81,8 +82,9 @@ func main() {
 		Text: core.StringPtr("Team, I know that times are tough! Product sales have been disappointing for the past three quarters. We have a competitive product, but we need to do a better job of selling it!"),
 	}
 	toneOptions = service.
-		NewToneOptions(toneanalyzerv3.ToneOptions_ContentType_ApplicationJSON).
-		SetToneInput(toneInput)
+		NewToneOptions().
+		SetToneInput(toneInput).
+		SetContentType(toneanalyzerv3.ToneOptions_ContentType_ApplicationJSON)
 	response, responseErr = service.Tone(toneOptions)
 
 	if responseErr != nil {
@@ -103,8 +105,9 @@ func main() {
 	if htmlByteErr != nil {
 		panic(htmlByteErr)
 	}
-	toneOptions = service.NewToneOptions(toneanalyzerv3.ToneOptions_ContentType_TextHTML).
-		SetBody(string(htmlByte))
+	toneOptions = service.NewToneOptions().
+		SetBody(string(htmlByte)).
+		SetContentType(toneanalyzerv3.ToneOptions_ContentType_TextHTML)
 	response, responseErr = service.Tone(toneOptions)
 
 	if responseErr != nil {

--- a/personalityinsightsv3/personality_insights_v3.go
+++ b/personalityinsightsv3/personality_insights_v3.go
@@ -454,7 +454,9 @@ type ProfileOptions struct {
 	Body *string `json:"body,omitempty"`
 
 	// The type of the input. For more information, see **Content types** in the method description.
-	ContentType *string `json:"Content-Type" validate:"required"`
+	//
+	// Default: `text/plain`.
+	ContentType *string `json:"Content-Type,omitempty"`
 
 	// The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants are
 	// treated as their parent language; for example, `en-US` is interpreted as `en`.
@@ -535,10 +537,8 @@ const (
 )
 
 // NewProfileOptions : Instantiate ProfileOptions
-func (personalityInsights *PersonalityInsightsV3) NewProfileOptions(contentType string) *ProfileOptions {
-	return &ProfileOptions{
-		ContentType: core.StringPtr(contentType),
-	}
+func (personalityInsights *PersonalityInsightsV3) NewProfileOptions() *ProfileOptions {
+	return &ProfileOptions{}
 }
 
 // SetContent : Allow user to set Content

--- a/personalityinsightsv3/personality_insights_v3_test.go
+++ b/personalityinsightsv3/personality_insights_v3_test.go
@@ -53,8 +53,9 @@ var _ = Describe("PersonalityInsightsV3", func() {
 				// First test with invalid (incomplete) input
 				content := new(personalityinsightsv3.Content)
 				profileOptions := testService.
-					NewProfileOptions(personalityinsightsv3.ProfileOptions_ContentType_TextPlain).
-					SetContent(content)
+					NewProfileOptions().
+					SetContent(content).
+					SetContentType(personalityinsightsv3.ProfileOptions_ContentType_TextPlain)
 				returnValue, returnValueErr = testService.Profile(profileOptions)
 				Expect(returnValueErr).ToNot(BeNil())
 				Expect(returnValue).To(BeNil())
@@ -65,8 +66,9 @@ var _ = Describe("PersonalityInsightsV3", func() {
 				contentItem.Content = &theContent
 				content.ContentItems = []personalityinsightsv3.ContentItem{*contentItem}
 				profileOptions = testService.
-					NewProfileOptions(personalityinsightsv3.ProfileOptions_ContentType_ApplicationJSON).
-					SetContent(content)
+					NewProfileOptions().
+					SetContent(content).
+					SetContentType(personalityinsightsv3.ProfileOptions_ContentType_ApplicationJSON)
 				returnValue, returnValueErr = testService.Profile(profileOptions)
 				Expect(returnValueErr).To(BeNil())
 				Expect(returnValue).ToNot(BeNil())
@@ -114,8 +116,9 @@ var _ = Describe("PersonalityInsightsV3", func() {
 				Expect(returnValueErr).NotTo(BeNil())
 
 				profileAsCsvOptions := testService.
-					NewProfileOptions(personalityinsightsv3.ProfileOptions_ContentType_TextHTML).
-					SetBody("html")
+					NewProfileOptions().
+					SetBody("html").
+					SetContentType(personalityinsightsv3.ProfileOptions_ContentType_TextHTML)
 				returnValue, returnValueErr = testService.ProfileAsCsv(profileAsCsvOptions)
 				Expect(returnValueErr).To(BeNil())
 				Expect(returnValue).ToNot(BeNil())

--- a/speechtotextv1/speech_to_text_v1.go
+++ b/speechtotextv1/speech_to_text_v1.go
@@ -2536,7 +2536,7 @@ type AddAudioOptions struct {
 	//
 	// For an archive-type resource, the media type of the archive file. For more information, see **Content types for
 	// archive-type resources** in the method description.
-	ContentType *string `json:"Content-Type" validate:"required"`
+	ContentType *string `json:"Content-Type,omitempty"`
 
 	// For an archive-type resource, specifies the format of the audio files that are contained in the archive file. The
 	// parameter accepts all of the audio formats that are supported for use with speech recognition, including the `rate`,
@@ -2601,12 +2601,11 @@ const (
 )
 
 // NewAddAudioOptions : Instantiate AddAudioOptions
-func (speechToText *SpeechToTextV1) NewAddAudioOptions(customizationID string, audioName string, audioResource io.ReadCloser, contentType string) *AddAudioOptions {
+func (speechToText *SpeechToTextV1) NewAddAudioOptions(customizationID string, audioName string, audioResource io.ReadCloser) *AddAudioOptions {
 	return &AddAudioOptions{
 		CustomizationID: core.StringPtr(customizationID),
 		AudioName:       core.StringPtr(audioName),
 		AudioResource:   &audioResource,
-		ContentType:     core.StringPtr(contentType),
 	}
 }
 
@@ -3289,7 +3288,7 @@ type CreateJobOptions struct {
 
 	// The format (MIME type) of the audio. For more information about specifying an audio format, see **Audio formats
 	// (content types)** in the method description.
-	ContentType *string `json:"Content-Type" validate:"required"`
+	ContentType *string `json:"Content-Type,omitempty"`
 
 	// The identifier of the model that is to be used for the recognition request. See [Languages and
 	// models](https://cloud.ibm.com/docs/services/speech-to-text/models.html).
@@ -3532,10 +3531,9 @@ const (
 )
 
 // NewCreateJobOptions : Instantiate CreateJobOptions
-func (speechToText *SpeechToTextV1) NewCreateJobOptions(audio io.ReadCloser, contentType string) *CreateJobOptions {
+func (speechToText *SpeechToTextV1) NewCreateJobOptions(audio io.ReadCloser) *CreateJobOptions {
 	return &CreateJobOptions{
-		Audio:       &audio,
-		ContentType: core.StringPtr(contentType),
+		Audio: &audio,
 	}
 }
 
@@ -4850,7 +4848,7 @@ type RecognizeOptions struct {
 
 	// The format (MIME type) of the audio. For more information about specifying an audio format, see **Audio formats
 	// (content types)** in the method description.
-	ContentType *string `json:"Content-Type" validate:"required"`
+	ContentType *string `json:"Content-Type,omitempty"`
 
 	// The identifier of the model that is to be used for the recognition request. See [Languages and
 	// models](https://cloud.ibm.com/docs/services/speech-to-text/models.html).
@@ -5035,10 +5033,9 @@ const (
 )
 
 // NewRecognizeOptions : Instantiate RecognizeOptions
-func (speechToText *SpeechToTextV1) NewRecognizeOptions(audio io.ReadCloser, contentType string) *RecognizeOptions {
+func (speechToText *SpeechToTextV1) NewRecognizeOptions(audio io.ReadCloser) *RecognizeOptions {
 	return &RecognizeOptions{
-		ContentType: core.StringPtr(contentType),
-		Audio:       &audio,
+		Audio: &audio,
 	}
 }
 

--- a/speechtotextv1/speech_to_text_v1_test.go
+++ b/speechtotextv1/speech_to_text_v1_test.go
@@ -178,7 +178,7 @@ var _ = Describe("SpeechToTextV1", func() {
 					panic(err)
 				}
 				recognizeOptions := testService.
-					NewRecognizeOptions(file, speechtotextv1.RecognizeOptions_ContentType_AudioWav)
+					NewRecognizeOptions(file)
 				returnValue, returnValueErr = testService.Recognize(recognizeOptions)
 				Expect(returnValueErr).To(BeNil())
 				Expect(returnValue).ToNot(BeNil())
@@ -309,7 +309,8 @@ var _ = Describe("SpeechToTextV1", func() {
 					panic(err)
 				}
 				createJobOptions := testService.
-					NewCreateJobOptions(file, speechtotextv1.CreateJobOptions_ContentType_AudioWav)
+					NewCreateJobOptions(file).
+					SetContentType(speechtotextv1.CreateJobOptions_ContentType_AudioWav)
 				returnValue, returnValueErr = testService.CreateJob(createJobOptions)
 				Expect(returnValueErr).To(BeNil())
 				Expect(returnValue).ToNot(BeNil())
@@ -1436,8 +1437,8 @@ var _ = Describe("SpeechToTextV1", func() {
 				addAudioOptions := testService.
 					NewAddAudioOptions(customizationID,
 						audioName,
-						file,
-						speechtotextv1.AddAudioOptions_ContentType_AudioWav)
+						file).
+					SetContentType(speechtotextv1.AddAudioOptions_ContentType_AudioWav)
 				returnValue, returnValueErr = testService.AddAudio(addAudioOptions)
 				Expect(returnValueErr).To(BeNil())
 				Expect(returnValue).ToNot(BeNil())

--- a/toneanalyzerv3/tone_analyzer_v3.go
+++ b/toneanalyzerv3/tone_analyzer_v3.go
@@ -422,7 +422,7 @@ type ToneOptions struct {
 
 	// The type of the input. A character encoding can be specified by including a `charset` parameter. For example,
 	// 'text/plain;charset=utf-8'.
-	ContentType *string `json:"Content-Type" validate:"required"`
+	ContentType *string `json:"Content-Type,omitempty"`
 
 	// Indicates whether the service is to return an analysis of each individual sentence in addition to its analysis of
 	// the full document. If `true` (the default), the service returns results for each sentence.
@@ -500,10 +500,8 @@ const (
 )
 
 // NewToneOptions : Instantiate ToneOptions
-func (toneAnalyzer *ToneAnalyzerV3) NewToneOptions(contentType string) *ToneOptions {
-	return &ToneOptions{
-		ContentType: core.StringPtr(contentType),
-	}
+func (toneAnalyzer *ToneAnalyzerV3) NewToneOptions() *ToneOptions {
+	return &ToneOptions{}
 }
 
 // SetToneInput : Allow user to set ToneInput

--- a/toneanalyzerv3/tone_analyzer_v3_test.go
+++ b/toneanalyzerv3/tone_analyzer_v3_test.go
@@ -47,8 +47,9 @@ var _ = Describe("ToneAnalyzerV3", func() {
 				Expect(returnValueErr).NotTo(BeNil())
 
 				toneOptions := testService.
-					NewToneOptions(toneanalyzerv3.ToneOptions_ContentType_TextPlain).
-					SetBody("I am feeling well today")
+					NewToneOptions().
+					SetBody("I am feeling well today").
+					SetContentType(toneanalyzerv3.ToneOptions_ContentType_TextPlain)
 				returnValue, returnValueErr = testService.Tone(toneOptions)
 				Expect(returnValueErr).To(BeNil())
 				Expect(returnValue).ToNot(BeNil())


### PR DESCRIPTION
related to https://github.ibm.com/Watson/developer-experience/issues/5930

The ContentType header parameter is required only if the x-content-type-required extension is set on the operation. So some operations with multiple consumes should not reply on content type to set the body in the request.