### PR TITLE
fix(response): return response directly for non-json response

### DIFF
--- a/core/watson.go
+++ b/core/watson.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -230,18 +229,14 @@ func (service *WatsonService) Request(req *http.Request, result interface{}) (*D
 		if IsJSONMimeType(contentType) && result != nil {
 			json.NewDecoder(resp.Body).Decode(&result)
 			response.Result = result
+			defer resp.Body.Close()
 		}
 	}
 
 	if response.Result == nil && result != nil {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return response, err
-		}
-		response.Result = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+		response.Result = resp.Body
 	}
 
-	defer resp.Body.Close()
 	return response, nil
 }
 

--- a/examples/personalityinsightsv3/personality_insights_v3.go
+++ b/examples/personalityinsightsv3/personality_insights_v3.go
@@ -129,4 +129,5 @@ func main() {
 		file.Write(buff.Bytes())
 		file.Close()
 	}
+	profCsvResult.Close()
 }

--- a/examples/texttospeechv1/text_to_speech_v1.go
+++ b/examples/texttospeechv1/text_to_speech_v1.go
@@ -51,4 +51,5 @@ func main() {
 
 		fmt.Println("Wrote synthesized text to " + fileName)
 	}
+	synthesizeResult.Close()
 }

--- a/personalityinsightsv3/personality_insights_v3_test.go
+++ b/personalityinsightsv3/personality_insights_v3_test.go
@@ -122,6 +122,7 @@ var _ = Describe("PersonalityInsightsV3", func() {
 
 				result := testService.GetProfileAsCsvResult(returnValue)
 				Expect(result).ToNot(BeNil())
+				result.Close()
 			})
 		})
 	})

--- a/texttospeechv1/text_to_speech_v1_integration_test.go
+++ b/texttospeechv1/text_to_speech_v1_integration_test.go
@@ -88,6 +88,7 @@ func TestSynthesize(t *testing.T) {
 
 	synthesize := service.GetSynthesizeResult(response)
 	assert.NotNil(t, synthesize)
+	synthesize.Close()
 }
 
 func TestPronunciation(t *testing.T) {

--- a/texttospeechv1/text_to_speech_v1_test.go
+++ b/texttospeechv1/text_to_speech_v1_test.go
@@ -183,6 +183,7 @@ var _ = Describe("TextToSpeechV1", func() {
 
 				result := testService.GetSynthesizeResult(returnValue)
 				Expect(result).ToNot(BeNil())
+				result.Close()
 			})
 		})
 	})


### PR DESCRIPTION
related to https://github.ibm.com/Watson/developer-experience/issues/5730

For non JSON response, return the body directly instead of making a copy. The user should close the reader so that there is no resource leak.

The `defer` is shifted only to JSON response. 