### PR TITLE
Added common package to support SDK headers

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ current_version = 0.5.0
 commit = True
 message = [skip ci] docs: Update version numbers from {current_version} -> {new_version}
 
-[bumpversion:file:core/version.go]
+[bumpversion:file:common/version.go]
 search = Version = "{current_version}"
 replace = Version = "{new_version}"
 

--- a/common/headers.go
+++ b/common/headers.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"fmt"
+	"runtime"
+)
+
+const (
+	HEADER_SDK_ANALYTICS = "X-IBMCloud-SDK-Analytics"
+	HEADER_USER_AGENT    = "User-Agent"
+
+	SDK_NAME = "watson-apis-go-sdk"
+)
+
+// GetSdkHeaders - returns the set of SDK-specific headers to be included in an outgoing request.
+func GetSdkHeaders(serviceName string, serviceVersion string, operationId string) map[string]string {
+	sdkHeaders := make(map[string]string)
+
+	sdkHeaders[HEADER_SDK_ANALYTICS] = fmt.Sprintf("service_name=%s;service_version=%s;operation_id=%s",
+		serviceName, serviceVersion, operationId)
+
+	sdkHeaders[HEADER_USER_AGENT] = GetUserAgentInfo()
+
+	return sdkHeaders
+}
+
+var userAgent string = fmt.Sprintf("%s-%s %s", SDK_NAME, Version, GetSystemInfo())
+
+func GetUserAgentInfo() string {
+	return userAgent
+}
+
+var systemInfo = fmt.Sprintf("(arch=%s; os=%s; go.version=%s)", runtime.GOARCH, runtime.GOOS, runtime.Version())
+
+func GetSystemInfo() string {
+	return systemInfo
+}

--- a/common/headers_test.go
+++ b/common/headers_test.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestGetSystemInfo(t *testing.T) {
+	var sysinfo = GetSystemInfo()
+	assert.NotNil(t, sysinfo)
+	assert.True(t, strings.Contains(sysinfo, "arch="))
+	assert.True(t, strings.Contains(sysinfo, "os="))
+	assert.True(t, strings.Contains(sysinfo, "go.version="))
+}
+
+func TestGetSdkHeaders(t *testing.T) {
+	var headers = GetSdkHeaders("myService", "v123", "myOperation")
+	assert.NotNil(t, headers)
+
+	var foundIt bool
+	_, foundIt = headers[HEADER_SDK_ANALYTICS]
+	assert.True(t, foundIt)
+
+	_, foundIt = headers[HEADER_USER_AGENT]
+	assert.True(t, foundIt)
+}

--- a/common/version.go
+++ b/common/version.go
@@ -1,0 +1,4 @@
+package common
+
+// Version of the SDK
+const Version = "0.5.0"


### PR DESCRIPTION
### Summary

Added a new "common" package to the go-sdk to provide the GetSdkHeaders() function,
which will be invoked by generated service functions.
