### PR TITLE
Release v0.10.0

### DIFF
--- a/assistantv1/assistant_v1.go
+++ b/assistantv1/assistant_v1.go
@@ -81,6 +81,10 @@ func NewAssistantV1(options *AssistantV1Options) (*AssistantV1, error) {
 // Message : Get response to user input
 // Send user input to a workspace and receive a response.
 //
+// **Note:** For most applications, there are significant advantages to using the v2 runtime API instead. These
+// advantages include ease of deployment, automatic state management, versioning, and search capabilities. For more
+// information, see the [documentation](https://cloud.ibm.com/docs/services/assistant?topic=assistant-api-overview).
+//
 // There is no rate limit for this operation.
 func (assistant *AssistantV1) Message(messageOptions *MessageOptions) (*core.DetailedResponse, error) {
 	if err := core.ValidateNotNil(messageOptions, "messageOptions cannot be nil"); err != nil {

--- a/assistantv2/assistant_v2.go
+++ b/assistantv2/assistant_v2.go
@@ -427,6 +427,12 @@ type DialogRuntimeResponseGeneric struct {
 	// **Note:** The **suggestions** property is part of the disambiguation feature, which is only available for Premium
 	// users.
 	Suggestions []DialogSuggestion `json:"suggestions,omitempty"`
+
+	// The title or introductory text to show before the response. This text is defined in the search skill configuration.
+	Header *string `json:"header,omitempty"`
+
+	// An array of objects containing search results.
+	Results []SearchResult `json:"results,omitempty"`
 }
 
 // Constants associated with the DialogRuntimeResponseGeneric.ResponseType property.
@@ -711,7 +717,7 @@ type MessageResponse struct {
 	Context *MessageContext `json:"context,omitempty"`
 }
 
-// RuntimeEntity : A term from the request that was identified as an entity.
+// RuntimeEntity : The entity value that was recognized in the user input.
 type RuntimeEntity struct {
 
 	// An entity detected in the input.
@@ -724,7 +730,7 @@ type RuntimeEntity struct {
 	// The term in the input text that was recognized as an entity value.
 	Value *string `json:"value" validate:"required"`
 
-	// A decimal percentage that represents Watson's confidence in the entity.
+	// A decimal percentage that represents Watson's confidence in the recognized entity.
 	Confidence *float64 `json:"confidence,omitempty"`
 
 	// Any metadata for the entity.
@@ -742,6 +748,88 @@ type RuntimeIntent struct {
 
 	// A decimal percentage that represents Watson's confidence in the intent.
 	Confidence *float64 `json:"confidence" validate:"required"`
+}
+
+// SearchResult : SearchResult struct
+type SearchResult struct {
+
+	// The unique identifier of the document in the Discovery service collection.
+	//
+	// This property is included in responses from search skills, which are a beta feature available only to Plus or
+	// Premium plan users.
+	ID *string `json:"id" validate:"required"`
+
+	// An object containing search result metadata from the Discovery service.
+	ResultMetadata *SearchResultMetadata `json:"result_metadata" validate:"required"`
+
+	// A description of the search result. This is taken from an abstract, summary, or highlight field in the Discovery
+	// service response, as specified in the search skill configuration.
+	Body *string `json:"body,omitempty"`
+
+	// The title of the search result. This is taken from a title or name field in the Discovery service response, as
+	// specified in the search skill configuration.
+	Title *string `json:"title,omitempty"`
+
+	// The URL of the original data object in its native data source.
+	URL *string `json:"url,omitempty"`
+
+	// An object containing segments of text from search results with query-matching text highlighted using HTML <em> tags.
+	Highlight *SearchResultHighlight `json:"highlight,omitempty"`
+}
+
+// SearchResultHighlight : An object containing segments of text from search results with query-matching text highlighted using HTML <em> tags.
+type SearchResultHighlight map[string]interface{}
+
+// SetBody : Allow user to set Body
+func (this *SearchResultHighlight) SetBody(Body *[]string) {
+	(*this)["body"] = Body
+}
+
+// GetBody : Allow user to get Body
+func (this *SearchResultHighlight) GetBody() *[]string {
+	return (*this)["body"].(*[]string)
+}
+
+// SetTitle : Allow user to set Title
+func (this *SearchResultHighlight) SetTitle(Title *[]string) {
+	(*this)["title"] = Title
+}
+
+// GetTitle : Allow user to get Title
+func (this *SearchResultHighlight) GetTitle() *[]string {
+	return (*this)["title"].(*[]string)
+}
+
+// SetURL : Allow user to set URL
+func (this *SearchResultHighlight) SetURL(URL *[]string) {
+	(*this)["url"] = URL
+}
+
+// GetURL : Allow user to get URL
+func (this *SearchResultHighlight) GetURL() *[]string {
+	return (*this)["url"].(*[]string)
+}
+
+// SetProperty : Allow user to set arbitrary property
+func (this *SearchResultHighlight) SetProperty(Key string, Value *[]string) {
+	(*this)[Key] = Value
+}
+
+// GetProperty : Allow user to get arbitrary property
+func (this *SearchResultHighlight) GetProperty(Key string) *[]string {
+	return (*this)[Key].(*[]string)
+}
+
+// SearchResultMetadata : An object containing search result metadata from the Discovery service.
+type SearchResultMetadata struct {
+
+	// The confidence score for the given result. For more information about how the confidence is calculated, see the
+	// Discovery service [documentation](../discovery#query-your-collection).
+	Confidence *float64 `json:"confidence,omitempty"`
+
+	// An unbounded measure of the relevance of a particular result, dependent on the query and matching document. A higher
+	// score indicates a greater match to the query parameters.
+	Score *float64 `json:"score,omitempty"`
 }
 
 // SessionResponse : SessionResponse struct

--- a/comparecomplyv1/compare_comply_v1.go
+++ b/comparecomplyv1/compare_comply_v1.go
@@ -1105,15 +1105,6 @@ type ClassifyReturn struct {
 	// Document elements identified by the service.
 	Elements []Element `json:"elements,omitempty"`
 
-	// Definition of tables identified in the input document.
-	Tables []Tables `json:"tables,omitempty"`
-
-	// The structure of the input document.
-	DocumentStructure *DocStructure `json:"document_structure,omitempty"`
-
-	// Definitions of the parties identified in the input document.
-	Parties []Parties `json:"parties,omitempty"`
-
 	// The date or dates on which the document becomes effective.
 	EffectiveDates []EffectiveDates `json:"effective_dates,omitempty"`
 
@@ -1124,7 +1115,22 @@ type ClassifyReturn struct {
 	TerminationDates []TerminationDates `json:"termination_dates,omitempty"`
 
 	// The document's contract type or types as declared in the document.
-	ContractType []ContractType `json:"contract_type,omitempty"`
+	ContractTypes []ContractTypes `json:"contract_types,omitempty"`
+
+	// The duration or durations of the contract.
+	ContractTerms []ContractTerms `json:"contract_terms,omitempty"`
+
+	// The document's payment duration or durations.
+	PaymentTerms []PaymentTerms `json:"payment_terms,omitempty"`
+
+	// Definition of tables identified in the input document.
+	Tables []Tables `json:"tables,omitempty"`
+
+	// The structure of the input document.
+	DocumentStructure *DocStructure `json:"document_structure,omitempty"`
+
+	// Definitions of the parties identified in the input document.
+	Parties []Parties `json:"parties,omitempty"`
 }
 
 // ColumnHeaderIds : An array of values, each being the `id` value of a column header that is applicable to the current cell.
@@ -1326,26 +1332,62 @@ const (
 	ContractAmts_ConfidenceLevel_Medium = "Medium"
 )
 
-// ContractType : The contract type identified in the input document.
-type ContractType struct {
+// ContractTerms : The duration or durations of the contract.
+type ContractTerms struct {
 
-	// The contract type.
+	// The confidence level in the identification of the contract term.
+	ConfidenceLevel *string `json:"confidence_level,omitempty"`
+
+	// The contract term (duration).
 	Text *string `json:"text,omitempty"`
 
-	// The confidence level in the identification of the termination date.
-	ConfidenceLevel *string `json:"confidence_level,omitempty"`
+	// The normalized form of the contract term, which is listed as a string. This element is optional; that is, the
+	// service output lists it only if normalized text exists.
+	TextNormalized *string `json:"text_normalized,omitempty"`
+
+	// The details of the normalized text, if applicable. This element is optional; that is, the service output lists it
+	// only if normalized text exists.
+	Interpretation *Interpretation `json:"interpretation,omitempty"`
+
+	// One or more hash values that you can send to IBM to provide feedback or receive support.
+	ProvenanceIds []string `json:"provenance_ids,omitempty"`
 
 	// The numeric location of the identified element in the document, represented with two integers labeled `begin` and
 	// `end`.
 	Location *Location `json:"location,omitempty"`
 }
 
-// Constants associated with the ContractType.ConfidenceLevel property.
-// The confidence level in the identification of the termination date.
+// Constants associated with the ContractTerms.ConfidenceLevel property.
+// The confidence level in the identification of the contract term.
 const (
-	ContractType_ConfidenceLevel_High   = "High"
-	ContractType_ConfidenceLevel_Low    = "Low"
-	ContractType_ConfidenceLevel_Medium = "Medium"
+	ContractTerms_ConfidenceLevel_High   = "High"
+	ContractTerms_ConfidenceLevel_Low    = "Low"
+	ContractTerms_ConfidenceLevel_Medium = "Medium"
+)
+
+// ContractTypes : The contract type identified in the input document.
+type ContractTypes struct {
+
+	// The confidence level in the identification of the contract type.
+	ConfidenceLevel *string `json:"confidence_level,omitempty"`
+
+	// The contract type.
+	Text *string `json:"text,omitempty"`
+
+	// One or more hash values that you can send to IBM to provide feedback or receive support.
+	ProvenanceIds []string `json:"provenance_ids,omitempty"`
+
+	// The numeric location of the identified element in the document, represented with two integers labeled `begin` and
+	// `end`.
+	Location *Location `json:"location,omitempty"`
+}
+
+// Constants associated with the ContractTypes.ConfidenceLevel property.
+// The confidence level in the identification of the contract type.
+const (
+	ContractTypes_ConfidenceLevel_High   = "High"
+	ContractTypes_ConfidenceLevel_Low    = "Low"
+	ContractTypes_ConfidenceLevel_Medium = "Medium"
 )
 
 // ConvertToHTMLOptions : The ConvertToHTML options.
@@ -2318,6 +2360,39 @@ type Parties struct {
 const (
 	Parties_Importance_Primary = "Primary"
 	Parties_Importance_Unknown = "Unknown"
+)
+
+// PaymentTerms : The document's payment duration or durations.
+type PaymentTerms struct {
+
+	// The confidence level in the identification of the payment term.
+	ConfidenceLevel *string `json:"confidence_level,omitempty"`
+
+	// The payment term (duration).
+	Text *string `json:"text,omitempty"`
+
+	// The normalized form of the payment term, which is listed as a string. This element is optional; that is, the service
+	// output lists it only if normalized text exists.
+	TextNormalized *string `json:"text_normalized,omitempty"`
+
+	// The details of the normalized text, if applicable. This element is optional; that is, the service output lists it
+	// only if normalized text exists.
+	Interpretation *Interpretation `json:"interpretation,omitempty"`
+
+	// One or more hash values that you can send to IBM to provide feedback or receive support.
+	ProvenanceIds []string `json:"provenance_ids,omitempty"`
+
+	// The numeric location of the identified element in the document, represented with two integers labeled `begin` and
+	// `end`.
+	Location *Location `json:"location,omitempty"`
+}
+
+// Constants associated with the PaymentTerms.ConfidenceLevel property.
+// The confidence level in the identification of the payment term.
+const (
+	PaymentTerms_ConfidenceLevel_High   = "High"
+	PaymentTerms_ConfidenceLevel_Low    = "Low"
+	PaymentTerms_ConfidenceLevel_Medium = "Medium"
 )
 
 // RowHeaderIds : An array of values, each being the `id` value of a row header that is applicable to this body cell.

--- a/comparecomplyv1/compare_comply_v1.go
+++ b/comparecomplyv1/compare_comply_v1.go
@@ -2530,6 +2530,18 @@ type TableReturn struct {
 	Tables []Tables `json:"tables,omitempty"`
 }
 
+// TableTitle : If identified, the title or caption of the current table of the form `Table x.: ...`. Empty when no title is
+// identified. When exposed, the `title` is also excluded from the `contexts` array of the same table.
+type TableTitle struct {
+
+	// The numeric location of the identified element in the document, represented with two integers labeled `begin` and
+	// `end`.
+	Location *Location `json:"location,omitempty"`
+
+	// The text of the identified table title or caption.
+	Text *string `json:"text,omitempty"`
+}
+
 // Tables : The contents of the tables extracted from a document.
 type Tables struct {
 
@@ -2542,6 +2554,10 @@ type Tables struct {
 
 	// The table's section title, if identified.
 	SectionTitle *SectionTitle `json:"section_title,omitempty"`
+
+	// If identified, the title or caption of the current table of the form `Table x.: ...`. Empty when no title is
+	// identified. When exposed, the `title` is also excluded from the `contexts` array of the same table.
+	Title *TableTitle `json:"title,omitempty"`
 
 	// An array of table-level cells that apply as headers to all the other cells in the current table.
 	TableHeaders []TableHeaders `json:"table_headers,omitempty"`

--- a/comparecomplyv1/compare_comply_v1.go
+++ b/comparecomplyv1/compare_comply_v1.go
@@ -1688,6 +1688,9 @@ type DocStructure struct {
 	// An array containing one object per section or subsection, in parallel with the `section_titles` array, that details
 	// the leading sentences in the corresponding section or subsection.
 	LeadingSentences []LeadingSentence `json:"leading_sentences,omitempty"`
+
+	// An array containing one object per paragraph, in parallel with the `section_titles` and `leading_sentences` arrays.
+	Paragraphs []Paragraphs `json:"paragraphs,omitempty"`
 }
 
 // Document : Basic information about the input document.
@@ -2358,23 +2361,34 @@ type Pagination struct {
 	Total *int64 `json:"total,omitempty"`
 }
 
+// Paragraphs : The locations of each paragraph in the input document.
+type Paragraphs struct {
+
+	// The numeric location of the identified element in the document, represented with two integers labeled `begin` and
+	// `end`.
+	Location *Location `json:"location,omitempty"`
+}
+
 // Parties : A party and its corresponding role, including address and contact information if identified.
 type Parties struct {
 
-	// A string identifying the party.
+	// The normalized form of the party's name.
 	Party *string `json:"party,omitempty"`
-
-	// A string that identifies the importance of the party.
-	Importance *string `json:"importance,omitempty"`
 
 	// A string identifying the party's role.
 	Role *string `json:"role,omitempty"`
 
-	// List of the party's address or addresses.
+	// A string that identifies the importance of the party.
+	Importance *string `json:"importance,omitempty"`
+
+	// A list of the party's address or addresses.
 	Addresses []Address `json:"addresses,omitempty"`
 
-	// List of the names and roles of contacts identified in the input document.
+	// A list of the names and roles of contacts identified in the input document.
 	Contacts []Contact `json:"contacts,omitempty"`
+
+	// A list of the party's mentions in the input document.
+	Mentions []Mention `json:"mentions,omitempty"`
 }
 
 // Constants associated with the Parties.Importance property.

--- a/comparecomplyv1/compare_comply_v1.go
+++ b/comparecomplyv1/compare_comply_v1.go
@@ -856,8 +856,10 @@ type Attribute struct {
 const (
 	Attribute_Type_Currency     = "Currency"
 	Attribute_Type_Datetime     = "DateTime"
+	Attribute_Type_Definedterm  = "DefinedTerm"
 	Attribute_Type_Duration     = "Duration"
 	Attribute_Type_Location     = "Location"
+	Attribute_Type_Number       = "Number"
 	Attribute_Type_Organization = "Organization"
 	Attribute_Type_Percentage   = "Percentage"
 	Attribute_Type_Person       = "Person"
@@ -984,6 +986,7 @@ const (
 	Category_Label_Insurance            = "Insurance"
 	Category_Label_IntellectualProperty = "Intellectual Property"
 	Category_Label_Liability            = "Liability"
+	Category_Label_OrderOfPrecedence    = "Order of Precedence"
 	Category_Label_PaymentTermsBilling  = "Payment Terms & Billing"
 	Category_Label_PricingTaxes         = "Pricing & Taxes"
 	Category_Label_Privacy              = "Privacy"
@@ -1020,6 +1023,7 @@ const (
 	CategoryComparison_Label_Insurance            = "Insurance"
 	CategoryComparison_Label_IntellectualProperty = "Intellectual Property"
 	CategoryComparison_Label_Liability            = "Liability"
+	CategoryComparison_Label_OrderOfPrecedence    = "Order of Precedence"
 	CategoryComparison_Label_PaymentTermsBilling  = "Payment Terms & Billing"
 	CategoryComparison_Label_PricingTaxes         = "Pricing & Taxes"
 	CategoryComparison_Label_Privacy              = "Privacy"
@@ -1713,11 +1717,18 @@ type Document struct {
 // EffectiveDates : An effective date.
 type EffectiveDates struct {
 
+	// The confidence level in the identification of the effective date.
+	ConfidenceLevel *string `json:"confidence_level,omitempty"`
+
 	// The effective date, listed as a string.
 	Text *string `json:"text,omitempty"`
 
-	// The confidence level in the identification of the effective date.
-	ConfidenceLevel *string `json:"confidence_level,omitempty"`
+	// The normalized form of the effective date, which is listed as a string. This element is optional; that is, the
+	// service output lists it only if normalized text exists.
+	TextNormalized *string `json:"text_normalized,omitempty"`
+
+	// One or more hash values that you can send to IBM to provide feedback or receive support.
+	ProvenanceIds []string `json:"provenance_ids,omitempty"`
 
 	// The numeric location of the identified element in the document, represented with two integers labeled `begin` and
 	// `end`.
@@ -2054,6 +2065,24 @@ type HTMLReturn struct {
 	HTML *string `json:"html,omitempty"`
 }
 
+// Interpretation : The details of the normalized text, if applicable. This element is optional; that is, the service output lists it
+// only if normalized text exists.
+type Interpretation struct {
+
+	// The value that was located in the normalized text.
+	Value *string `json:"value,omitempty"`
+
+	// An integer or float expressing the numeric value of the `value` key.
+	NumericValue *float64 `json:"numeric_value,omitempty"`
+
+	// A string listing the unit of the value that was found in the normalized text.
+	//
+	// **Note:** The value of `unit` is the [ISO-4217 currency code](https://www.iso.org/iso-4217-currency-codes.html)
+	// identified for the currency amount (for example, `USD` or `EUR`). If the service cannot disambiguate a currency
+	// symbol (for example, `$` or `£`), the value of `unit` contains the ambiguous symbol as-is.
+	Unit *string `json:"unit,omitempty"`
+}
+
 // Key : A key in a key-value pair.
 type Key struct {
 
@@ -2307,6 +2336,17 @@ type Location struct {
 
 	// The element's `end` index.
 	End *int64 `json:"end" validate:"required"`
+}
+
+// Mention : A mention of a party.
+type Mention struct {
+
+	// The name of the party.
+	Text *string `json:"text,omitempty"`
+
+	// The numeric location of the identified element in the document, represented with two integers labeled `begin` and
+	// `end`.
+	Location *Location `json:"location,omitempty"`
 }
 
 // OriginalLabelsIn : The original labeling from the input document, without the submitted feedback.

--- a/comparecomplyv1/compare_comply_v1.go
+++ b/comparecomplyv1/compare_comply_v1.go
@@ -1310,14 +1310,36 @@ type Contact struct {
 	Role *string `json:"role,omitempty"`
 }
 
+// Contexts : Text that is related to the contents of the table and that precedes or follows the current table.
+type Contexts struct {
+
+	// The related text.
+	Text *string `json:"text,omitempty"`
+
+	// The numeric location of the identified element in the document, represented with two integers labeled `begin` and
+	// `end`.
+	Location *Location `json:"location,omitempty"`
+}
+
 // ContractAmts : A monetary amount identified in the input document.
 type ContractAmts struct {
+
+	// The confidence level in the identification of the contract amount.
+	ConfidenceLevel *string `json:"confidence_level,omitempty"`
 
 	// The monetary amount.
 	Text *string `json:"text,omitempty"`
 
-	// The confidence level in the identification of the contract amount.
-	ConfidenceLevel *string `json:"confidence_level,omitempty"`
+	// The normalized form of the amount, which is listed as a string. This element is optional; that is, the service
+	// output lists it only if normalized text exists.
+	TextNormalized *string `json:"text_normalized,omitempty"`
+
+	// The details of the normalized text, if applicable. This element is optional; that is, the service output lists it
+	// only if normalized text exists.
+	Interpretation *Interpretation `json:"interpretation,omitempty"`
+
+	// One or more hash values that you can send to IBM to provide feedback or receive support.
+	ProvenanceIds []string `json:"provenance_ids,omitempty"`
 
 	// The numeric location of the identified element in the document, represented with two integers labeled `begin` and
 	// `end`.
@@ -2570,22 +2592,33 @@ type Tables struct {
 	// current table.
 	ColumnHeaders []ColumnHeaders `json:"column_headers,omitempty"`
 
-	// An array of key-value pairs identified in the current table.
-	KeyValuePairs []KeyValuePair `json:"key_value_pairs,omitempty"`
-
 	// An array of cells that are neither table header nor column header nor row header cells, of the current table with
 	// corresponding row and column header associations.
 	BodyCells []BodyCells `json:"body_cells,omitempty"`
+
+	// An array of objects that list text that is related to the table contents and that precedes or follows the current
+	// table.
+	Contexts []Contexts `json:"contexts,omitempty"`
+
+	// An array of key-value pairs identified in the current table.
+	KeyValuePairs []KeyValuePair `json:"key_value_pairs,omitempty"`
 }
 
 // TerminationDates : Termination dates identified in the input document.
 type TerminationDates struct {
 
+	// The confidence level in the identification of the termination date.
+	ConfidenceLevel *string `json:"confidence_level,omitempty"`
+
 	// The termination date.
 	Text *string `json:"text,omitempty"`
 
-	// The confidence level in the identification of the termination date.
-	ConfidenceLevel *string `json:"confidence_level,omitempty"`
+	// The normalized form of the termination date, which is listed as a string. This element is optional; that is, the
+	// service output lists it only if normalized text exists.
+	TextNormalized *string `json:"text_normalized,omitempty"`
+
+	// One or more hash values that you can send to IBM to provide feedback or receive support.
+	ProvenanceIds []string `json:"provenance_ids,omitempty"`
 
 	// The numeric location of the identified element in the document, represented with two integers labeled `begin` and
 	// `end`.

--- a/comparecomplyv1/compare_comply_v1.go
+++ b/comparecomplyv1/compare_comply_v1.go
@@ -39,6 +39,8 @@ type CompareComplyV1 struct {
 type CompareComplyV1Options struct {
 	Version            string
 	URL                string
+	Username           string
+	Password           string
 	IAMApiKey          string
 	IAMAccessToken     string
 	IAMURL             string
@@ -58,6 +60,8 @@ func NewCompareComplyV1(options *CompareComplyV1Options) (*CompareComplyV1, erro
 	serviceOptions := &core.ServiceOptions{
 		Version:            options.Version,
 		URL:                options.URL,
+		Username:           options.Username,
+		Password:           options.Password,
 		IAMApiKey:          options.IAMApiKey,
 		IAMAccessToken:     options.IAMAccessToken,
 		IAMURL:             options.IAMURL,

--- a/languagetranslatorv3/language_translator_v3.go
+++ b/languagetranslatorv3/language_translator_v3.go
@@ -308,7 +308,7 @@ func (languageTranslator *LanguageTranslatorV3) GetListModelsResult(response *co
 // to <b>250 MB</b>. To successfully train with a parallel corpus you must have at least <b>5,000 parallel sentences</b>
 // in your corpus.
 //
-// You can have a <b>maxium of 10 custom models per language pair</b>.
+// You can have a <b>maximum of 10 custom models per language pair</b>.
 func (languageTranslator *LanguageTranslatorV3) CreateModel(createModelOptions *CreateModelOptions) (*core.DetailedResponse, error) {
 	if err := core.ValidateNotNil(createModelOptions, "createModelOptions cannot be nil"); err != nil {
 		return nil, err

--- a/naturallanguageunderstandingv1/natural_language_understanding_v1.go
+++ b/naturallanguageunderstandingv1/natural_language_understanding_v1.go
@@ -40,15 +40,15 @@ type NaturalLanguageUnderstandingV1 struct {
 
 // NaturalLanguageUnderstandingV1Options : Service options
 type NaturalLanguageUnderstandingV1Options struct {
-	Version         string
-	URL             string
-	Username        string
-	Password        string
-	IAMApiKey       string
-	IAMAccessToken  string
-	IAMURL          string
-	IAMClientId     string
-	IAMClientSecret string
+	Version            string
+	URL                string
+	Username           string
+	Password           string
+	IAMApiKey          string
+	IAMAccessToken     string
+	IAMURL             string
+	IAMClientId        string
+	IAMClientSecret    string
 	ICP4DAccessToken   string
 	ICP4DURL           string
 	AuthenticationType string
@@ -61,15 +61,15 @@ func NewNaturalLanguageUnderstandingV1(options *NaturalLanguageUnderstandingV1Op
 	}
 
 	serviceOptions := &core.ServiceOptions{
-		Version:         options.Version,
-		URL:             options.URL,
-		Username:        options.Username,
-		Password:        options.Password,
-		IAMApiKey:       options.IAMApiKey,
-		IAMAccessToken:  options.IAMAccessToken,
-		IAMURL:          options.IAMURL,
-		IAMClientId:     options.IAMClientId,
-		IAMClientSecret: options.IAMClientSecret,
+		Version:            options.Version,
+		URL:                options.URL,
+		Username:           options.Username,
+		Password:           options.Password,
+		IAMApiKey:          options.IAMApiKey,
+		IAMAccessToken:     options.IAMAccessToken,
+		IAMURL:             options.IAMURL,
+		IAMClientId:        options.IAMClientId,
+		IAMClientSecret:    options.IAMClientSecret,
 		ICP4DAccessToken:   options.ICP4DAccessToken,
 		ICP4DURL:           options.ICP4DURL,
 		AuthenticationType: options.AuthenticationType,
@@ -688,6 +688,11 @@ type EntitiesResult struct {
 	// Relevance score from 0 to 1. Higher values indicate greater relevance.
 	Relevance *float64 `json:"relevance,omitempty"`
 
+	// Confidence in the entity identification from 0 to 1. Higher values indicate higher confidence. In standard entities
+	// requests, confidence is returned only for English text. All entities requests that use custom models return the
+	// confidence score.
+	Confidence *float64 `json:"confidence,omitempty"`
+
 	// Entity mentions and locations.
 	Mentions []EntityMention `json:"mentions,omitempty"`
 
@@ -712,6 +717,11 @@ type EntityMention struct {
 
 	// Character offsets indicating the beginning and end of the mention in the analyzed text.
 	Location []int64 `json:"location,omitempty"`
+
+	// Confidence in the entity identification from 0 to 1. Higher values indicate higher confidence. In standard entities
+	// requests, confidence is returned only for English text. All entities requests that use custom models return the
+	// confidence score.
+	Confidence *float64 `json:"confidence,omitempty"`
 }
 
 // FeatureSentimentResults : FeatureSentimentResults struct
@@ -1081,7 +1091,6 @@ type SyntaxOptionsTokens struct {
 
 // SyntaxResult : Tokens and sentences returned from syntax analysis.
 type SyntaxResult struct {
-
 	Tokens []TokenResult `json:"tokens,omitempty"`
 
 	Sentences []SentenceResult `json:"sentences,omitempty"`
@@ -1128,21 +1137,21 @@ type TokenResult struct {
 // The part of speech of the token. For descriptions of the values, see [Universal Dependencies POS
 // tags](https://universaldependencies.org/u/pos/).
 const (
-	TokenResult_PartOfSpeech_Adj = "ADJ"
-	TokenResult_PartOfSpeech_Adp = "ADP"
-	TokenResult_PartOfSpeech_Adv = "ADV"
-	TokenResult_PartOfSpeech_Aux = "AUX"
+	TokenResult_PartOfSpeech_Adj   = "ADJ"
+	TokenResult_PartOfSpeech_Adp   = "ADP"
+	TokenResult_PartOfSpeech_Adv   = "ADV"
+	TokenResult_PartOfSpeech_Aux   = "AUX"
 	TokenResult_PartOfSpeech_Cconj = "CCONJ"
-	TokenResult_PartOfSpeech_Det = "DET"
-	TokenResult_PartOfSpeech_Intj = "INTJ"
-	TokenResult_PartOfSpeech_Noun = "NOUN"
-	TokenResult_PartOfSpeech_Num = "NUM"
-	TokenResult_PartOfSpeech_Part = "PART"
-	TokenResult_PartOfSpeech_Pron = "PRON"
+	TokenResult_PartOfSpeech_Det   = "DET"
+	TokenResult_PartOfSpeech_Intj  = "INTJ"
+	TokenResult_PartOfSpeech_Noun  = "NOUN"
+	TokenResult_PartOfSpeech_Num   = "NUM"
+	TokenResult_PartOfSpeech_Part  = "PART"
+	TokenResult_PartOfSpeech_Pron  = "PRON"
 	TokenResult_PartOfSpeech_Propn = "PROPN"
 	TokenResult_PartOfSpeech_Punct = "PUNCT"
 	TokenResult_PartOfSpeech_Sconj = "SCONJ"
-	TokenResult_PartOfSpeech_Sym = "SYM"
-	TokenResult_PartOfSpeech_Verb = "VERB"
-	TokenResult_PartOfSpeech_X = "X"
+	TokenResult_PartOfSpeech_Sym   = "SYM"
+	TokenResult_PartOfSpeech_Verb  = "VERB"
+	TokenResult_PartOfSpeech_X     = "X"
 )

--- a/personalityinsightsv3/personality_insights_v3.go
+++ b/personalityinsightsv3/personality_insights_v3.go
@@ -516,8 +516,6 @@ type ProfileOptions struct {
 	ConsumptionPreferences *bool `json:"consumption_preferences,omitempty"`
 
 	// The type of the input. For more information, see **Content types** in the method description.
-	//
-	// Default: `text/plain`.
 	ContentType *string `json:"Content-Type,omitempty"`
 
 	// Allows users to set headers to be GDPR compliant
@@ -562,8 +560,6 @@ const (
 
 // Constants associated with the ProfileOptions.ContentType property.
 // The type of the input. For more information, see **Content types** in the method description.
-//
-// Default: `text/plain`.
 const (
 	ProfileOptions_ContentType_ApplicationJSON = "application/json"
 	ProfileOptions_ContentType_TextHTML        = "text/html"

--- a/speechtotextv1/speech_to_text_v1.go
+++ b/speechtotextv1/speech_to_text_v1.go
@@ -2727,6 +2727,11 @@ type AcousticModel struct {
 	// provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
 	Created *string `json:"created,omitempty"`
 
+	// The date and time in Coordinated Universal Time (UTC) at which the custom acoustic model was last modified. The
+	// `created` and `updated` fields are equal when an acoustic model is first added but has yet to be updated. The value
+	// is provided in full ISO 8601 format (YYYY-MM-DDThh:mm:ss.sTZD).
+	Updated *string `json:"updated,omitempty"`
+
 	// The language identifier of the custom acoustic model (for example, `en-US`).
 	Language *string `json:"language,omitempty"`
 
@@ -4855,6 +4860,11 @@ type LanguageModel struct {
 	// The date and time in Coordinated Universal Time (UTC) at which the custom language model was created. The value is
 	// provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
 	Created *string `json:"created,omitempty"`
+
+	// The date and time in Coordinated Universal Time (UTC) at which the custom language model was last modified. The
+	// `created` and `updated` fields are equal when a language model is first added but has yet to be updated. The value
+	// is provided in full ISO 8601 format (YYYY-MM-DDThh:mm:ss.sTZD).
+	Updated *string `json:"updated,omitempty"`
 
 	// The language identifier of the custom language model (for example, `en-US`).
 	Language *string `json:"language,omitempty"`

--- a/speechtotextv1/speech_to_text_v1.go
+++ b/speechtotextv1/speech_to_text_v1.go
@@ -5218,7 +5218,8 @@ type ProcessedAudio struct {
 	SpeakerLabels *float32 `json:"speaker_labels,omitempty"`
 }
 
-// ProcessingMetrics : If processing metrics are requested, information about the service's processing of the input audio.
+// ProcessingMetrics : If processing metrics are requested, information about the service's processing of the input audio. Processing
+// metrics are not available with the synchronous **Recognize audio** method.
 type ProcessingMetrics struct {
 
 	// Detailed timing information about the service's processing of the input audio.
@@ -5891,6 +5892,10 @@ type SpeechRecognitionResults struct {
 	// are also requested for methods that support them, it is possible for a `SpeechRecognitionResults` object to include
 	// only the `speaker_labels` field.
 	SpeakerLabels []SpeakerLabelsResult `json:"speaker_labels,omitempty"`
+
+	// If processing metrics are requested, information about the service's processing of the input audio. Processing
+	// metrics are not available with the synchronous **Recognize audio** method.
+	ProcessingMetrics *ProcessingMetrics `json:"processing_metrics,omitempty"`
 
 	// If audio metrics are requested, information about the signal characteristics of the input audio.
 	AudioMetrics *AudioMetrics `json:"audio_metrics,omitempty"`

--- a/texttospeechv1/text_to_speech_v1.go
+++ b/texttospeechv1/text_to_speech_v1.go
@@ -137,8 +137,8 @@ func (textToSpeech *TextToSpeechV1) GetListVoicesResult(response *core.DetailedR
 
 // GetVoice : Get a voice
 // Gets information about the specified voice. The information includes the name, language, gender, and other details
-// about the voice. Specify a customization ID to obtain information for that custom voice model of the specified voice.
-// To list information about all available voices, use the **List voices** method.
+// about the voice. Specify a customization ID to obtain information for a custom voice model that is defined for the
+// language of the specified voice. To list information about all available voices, use the **List voices** method.
 //
 // **See also:** [Listing a specific
 // voice](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-voices#listVoice).
@@ -1007,8 +1007,8 @@ func (textToSpeech *TextToSpeechV1) DeleteUserData(deleteUserDataOptions *Delete
 // AddWordOptions : The AddWord options.
 type AddWordOptions struct {
 
-	// The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-	// for the instance of the service that owns the custom model.
+	// The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance
+	// of the service that owns the custom model.
 	CustomizationID *string `json:"customization_id" validate:"required"`
 
 	// The word that is to be added or updated for the custom voice model.
@@ -1096,8 +1096,8 @@ func (options *AddWordOptions) SetHeaders(param map[string]string) *AddWordOptio
 // AddWordsOptions : The AddWords options.
 type AddWordsOptions struct {
 
-	// The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-	// for the instance of the service that owns the custom model.
+	// The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance
+	// of the service that owns the custom model.
 	CustomizationID *string `json:"customization_id" validate:"required"`
 
 	// The **Add custom words** method accepts an array of `Word` objects. Each object provides a word that is to be added
@@ -1232,8 +1232,8 @@ func (options *DeleteUserDataOptions) SetHeaders(param map[string]string) *Delet
 // DeleteVoiceModelOptions : The DeleteVoiceModel options.
 type DeleteVoiceModelOptions struct {
 
-	// The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-	// for the instance of the service that owns the custom model.
+	// The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance
+	// of the service that owns the custom model.
 	CustomizationID *string `json:"customization_id" validate:"required"`
 
 	// Allows users to set headers to be GDPR compliant
@@ -1262,8 +1262,8 @@ func (options *DeleteVoiceModelOptions) SetHeaders(param map[string]string) *Del
 // DeleteWordOptions : The DeleteWord options.
 type DeleteWordOptions struct {
 
-	// The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-	// for the instance of the service that owns the custom model.
+	// The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance
+	// of the service that owns the custom model.
 	CustomizationID *string `json:"customization_id" validate:"required"`
 
 	// The word that is to be deleted from the custom voice model.
@@ -1316,8 +1316,8 @@ type GetPronunciationOptions struct {
 	// The customization ID (GUID) of a custom voice model for which the pronunciation is to be returned. The language of a
 	// specified custom model must match the language of the specified voice. If the word is not defined in the specified
 	// custom model, the service returns the default translation for the custom model's language. You must make the request
-	// with service credentials created for the instance of the service that owns the custom model. Omit the parameter to
-	// see the translation for the specified voice with no customization.
+	// with credentials for the instance of the service that owns the custom model. Omit the parameter to see the
+	// translation for the specified voice with no customization.
 	CustomizationID *string `json:"customization_id,omitempty"`
 
 	// Allows users to set headers to be GDPR compliant
@@ -1328,25 +1328,32 @@ type GetPronunciationOptions struct {
 // A voice that specifies the language in which the pronunciation is to be returned. All voices for the same language
 // (for example, `en-US`) return the same translation.
 const (
-	GetPronunciationOptions_Voice_DeDeBirgitv2voice    = "de-DE_BirgitV2Voice"
+	GetPronunciationOptions_Voice_DeDeBirgitv3voice    = "de-DE_BirgitV3Voice"
 	GetPronunciationOptions_Voice_DeDeBirgitvoice      = "de-DE_BirgitVoice"
-	GetPronunciationOptions_Voice_DeDeDieterv2voice    = "de-DE_DieterV2Voice"
+	GetPronunciationOptions_Voice_DeDeDieterv3voice    = "de-DE_DieterV3Voice"
 	GetPronunciationOptions_Voice_DeDeDietervoice      = "de-DE_DieterVoice"
+	GetPronunciationOptions_Voice_EnGbKatev3voice      = "en-GB_KateV3Voice"
 	GetPronunciationOptions_Voice_EnGbKatevoice        = "en-GB_KateVoice"
-	GetPronunciationOptions_Voice_EnUsAllisonv2voice   = "en-US_AllisonV2Voice"
+	GetPronunciationOptions_Voice_EnUsAllisonv3voice   = "en-US_AllisonV3Voice"
 	GetPronunciationOptions_Voice_EnUsAllisonvoice     = "en-US_AllisonVoice"
-	GetPronunciationOptions_Voice_EnUsLisav2voice      = "en-US_LisaV2Voice"
+	GetPronunciationOptions_Voice_EnUsLisav3voice      = "en-US_LisaV3Voice"
 	GetPronunciationOptions_Voice_EnUsLisavoice        = "en-US_LisaVoice"
-	GetPronunciationOptions_Voice_EnUsMichaelv2voice   = "en-US_MichaelV2Voice"
+	GetPronunciationOptions_Voice_EnUsMichaelv3voice   = "en-US_MichaelV3Voice"
 	GetPronunciationOptions_Voice_EnUsMichaelvoice     = "en-US_MichaelVoice"
+	GetPronunciationOptions_Voice_EsEsEnriquev3voice   = "es-ES_EnriqueV3Voice"
 	GetPronunciationOptions_Voice_EsEsEnriquevoice     = "es-ES_EnriqueVoice"
+	GetPronunciationOptions_Voice_EsEsLaurav3voice     = "es-ES_LauraV3Voice"
 	GetPronunciationOptions_Voice_EsEsLauravoice       = "es-ES_LauraVoice"
+	GetPronunciationOptions_Voice_EsLaSofiav3voice     = "es-LA_SofiaV3Voice"
 	GetPronunciationOptions_Voice_EsLaSofiavoice       = "es-LA_SofiaVoice"
+	GetPronunciationOptions_Voice_EsUsSofiav3voice     = "es-US_SofiaV3Voice"
 	GetPronunciationOptions_Voice_EsUsSofiavoice       = "es-US_SofiaVoice"
+	GetPronunciationOptions_Voice_FrFrReneev3voice     = "fr-FR_ReneeV3Voice"
 	GetPronunciationOptions_Voice_FrFrReneevoice       = "fr-FR_ReneeVoice"
-	GetPronunciationOptions_Voice_ItItFrancescav2voice = "it-IT_FrancescaV2Voice"
+	GetPronunciationOptions_Voice_ItItFrancescav3voice = "it-IT_FrancescaV3Voice"
 	GetPronunciationOptions_Voice_ItItFrancescavoice   = "it-IT_FrancescaVoice"
 	GetPronunciationOptions_Voice_JaJpEmivoice         = "ja-JP_EmiVoice"
+	GetPronunciationOptions_Voice_PtBrIsabelav3voice   = "pt-BR_IsabelaV3Voice"
 	GetPronunciationOptions_Voice_PtBrIsabelavoice     = "pt-BR_IsabelaVoice"
 )
 
@@ -1398,8 +1405,8 @@ func (options *GetPronunciationOptions) SetHeaders(param map[string]string) *Get
 // GetVoiceModelOptions : The GetVoiceModel options.
 type GetVoiceModelOptions struct {
 
-	// The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-	// for the instance of the service that owns the custom model.
+	// The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance
+	// of the service that owns the custom model.
 	CustomizationID *string `json:"customization_id" validate:"required"`
 
 	// Allows users to set headers to be GDPR compliant
@@ -1432,8 +1439,8 @@ type GetVoiceOptions struct {
 	Voice *string `json:"voice" validate:"required"`
 
 	// The customization ID (GUID) of a custom voice model for which information is to be returned. You must make the
-	// request with service credentials created for the instance of the service that owns the custom model. Omit the
-	// parameter to see information about the specified voice with no customization.
+	// request with credentials for the instance of the service that owns the custom model. Omit the parameter to see
+	// information about the specified voice with no customization.
 	CustomizationID *string `json:"customization_id,omitempty"`
 
 	// Allows users to set headers to be GDPR compliant
@@ -1443,25 +1450,32 @@ type GetVoiceOptions struct {
 // Constants associated with the GetVoiceOptions.Voice property.
 // The voice for which information is to be returned.
 const (
-	GetVoiceOptions_Voice_DeDeBirgitv2voice    = "de-DE_BirgitV2Voice"
+	GetVoiceOptions_Voice_DeDeBirgitv3voice    = "de-DE_BirgitV3Voice"
 	GetVoiceOptions_Voice_DeDeBirgitvoice      = "de-DE_BirgitVoice"
-	GetVoiceOptions_Voice_DeDeDieterv2voice    = "de-DE_DieterV2Voice"
+	GetVoiceOptions_Voice_DeDeDieterv3voice    = "de-DE_DieterV3Voice"
 	GetVoiceOptions_Voice_DeDeDietervoice      = "de-DE_DieterVoice"
+	GetVoiceOptions_Voice_EnGbKatev3voice      = "en-GB_KateV3Voice"
 	GetVoiceOptions_Voice_EnGbKatevoice        = "en-GB_KateVoice"
-	GetVoiceOptions_Voice_EnUsAllisonv2voice   = "en-US_AllisonV2Voice"
+	GetVoiceOptions_Voice_EnUsAllisonv3voice   = "en-US_AllisonV3Voice"
 	GetVoiceOptions_Voice_EnUsAllisonvoice     = "en-US_AllisonVoice"
-	GetVoiceOptions_Voice_EnUsLisav2voice      = "en-US_LisaV2Voice"
+	GetVoiceOptions_Voice_EnUsLisav3voice      = "en-US_LisaV3Voice"
 	GetVoiceOptions_Voice_EnUsLisavoice        = "en-US_LisaVoice"
-	GetVoiceOptions_Voice_EnUsMichaelv2voice   = "en-US_MichaelV2Voice"
+	GetVoiceOptions_Voice_EnUsMichaelv3voice   = "en-US_MichaelV3Voice"
 	GetVoiceOptions_Voice_EnUsMichaelvoice     = "en-US_MichaelVoice"
+	GetVoiceOptions_Voice_EsEsEnriquev3voice   = "es-ES_EnriqueV3Voice"
 	GetVoiceOptions_Voice_EsEsEnriquevoice     = "es-ES_EnriqueVoice"
+	GetVoiceOptions_Voice_EsEsLaurav3voice     = "es-ES_LauraV3Voice"
 	GetVoiceOptions_Voice_EsEsLauravoice       = "es-ES_LauraVoice"
+	GetVoiceOptions_Voice_EsLaSofiav3voice     = "es-LA_SofiaV3Voice"
 	GetVoiceOptions_Voice_EsLaSofiavoice       = "es-LA_SofiaVoice"
+	GetVoiceOptions_Voice_EsUsSofiav3voice     = "es-US_SofiaV3Voice"
 	GetVoiceOptions_Voice_EsUsSofiavoice       = "es-US_SofiaVoice"
+	GetVoiceOptions_Voice_FrFrReneev3voice     = "fr-FR_ReneeV3Voice"
 	GetVoiceOptions_Voice_FrFrReneevoice       = "fr-FR_ReneeVoice"
-	GetVoiceOptions_Voice_ItItFrancescav2voice = "it-IT_FrancescaV2Voice"
+	GetVoiceOptions_Voice_ItItFrancescav3voice = "it-IT_FrancescaV3Voice"
 	GetVoiceOptions_Voice_ItItFrancescavoice   = "it-IT_FrancescaVoice"
 	GetVoiceOptions_Voice_JaJpEmivoice         = "ja-JP_EmiVoice"
+	GetVoiceOptions_Voice_PtBrIsabelav3voice   = "pt-BR_IsabelaV3Voice"
 	GetVoiceOptions_Voice_PtBrIsabelavoice     = "pt-BR_IsabelaVoice"
 )
 
@@ -1493,8 +1507,8 @@ func (options *GetVoiceOptions) SetHeaders(param map[string]string) *GetVoiceOpt
 // GetWordOptions : The GetWord options.
 type GetWordOptions struct {
 
-	// The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-	// for the instance of the service that owns the custom model.
+	// The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance
+	// of the service that owns the custom model.
 	CustomizationID *string `json:"customization_id" validate:"required"`
 
 	// The word that is to be queried from the custom voice model.
@@ -1533,8 +1547,8 @@ func (options *GetWordOptions) SetHeaders(param map[string]string) *GetWordOptio
 // ListVoiceModelsOptions : The ListVoiceModels options.
 type ListVoiceModelsOptions struct {
 
-	// The language for which custom voice models that are owned by the requesting service credentials are to be returned.
-	// Omit the parameter to see all custom voice models that are owned by the requester.
+	// The language for which custom voice models that are owned by the requesting credentials are to be returned. Omit the
+	// parameter to see all custom voice models that are owned by the requester.
 	Language *string `json:"language,omitempty"`
 
 	// Allows users to set headers to be GDPR compliant
@@ -1542,8 +1556,8 @@ type ListVoiceModelsOptions struct {
 }
 
 // Constants associated with the ListVoiceModelsOptions.Language property.
-// The language for which custom voice models that are owned by the requesting service credentials are to be returned.
-// Omit the parameter to see all custom voice models that are owned by the requester.
+// The language for which custom voice models that are owned by the requesting credentials are to be returned. Omit the
+// parameter to see all custom voice models that are owned by the requester.
 const (
 	ListVoiceModelsOptions_Language_DeDe = "de-DE"
 	ListVoiceModelsOptions_Language_EnGb = "en-GB"
@@ -1595,8 +1609,8 @@ func (options *ListVoicesOptions) SetHeaders(param map[string]string) *ListVoice
 // ListWordsOptions : The ListWords options.
 type ListWordsOptions struct {
 
-	// The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-	// for the instance of the service that owns the custom model.
+	// The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance
+	// of the service that owns the custom model.
 	CustomizationID *string `json:"customization_id" validate:"required"`
 
 	// Allows users to set headers to be GDPR compliant
@@ -1652,15 +1666,13 @@ type SynthesizeOptions struct {
 
 	// The customization ID (GUID) of a custom voice model to use for the synthesis. If a custom voice model is specified,
 	// it is guaranteed to work only if it matches the language of the indicated voice. You must make the request with
-	// service credentials created for the instance of the service that owns the custom model. Omit the parameter to use
-	// the specified voice with no customization.
+	// credentials for the instance of the service that owns the custom model. Omit the parameter to use the specified
+	// voice with no customization.
 	CustomizationID *string `json:"customization_id,omitempty"`
 
 	// The requested format (MIME type) of the audio. You can use the `Accept` header or the `accept` parameter to specify
 	// the audio format. For more information about specifying an audio format, see **Audio formats (accept types)** in the
 	// method description.
-	//
-	// Default: `audio/ogg;codecs=opus`.
 	Accept *string `json:"Accept,omitempty"`
 
 	// Allows users to set headers to be GDPR compliant
@@ -1671,24 +1683,37 @@ type SynthesizeOptions struct {
 // The voice to use for synthesis.
 const (
 	SynthesizeOptions_Voice_DeDeBirgitv2voice    = "de-DE_BirgitV2Voice"
+	SynthesizeOptions_Voice_DeDeBirgitv3voice    = "de-DE_BirgitV3Voice"
 	SynthesizeOptions_Voice_DeDeBirgitvoice      = "de-DE_BirgitVoice"
 	SynthesizeOptions_Voice_DeDeDieterv2voice    = "de-DE_DieterV2Voice"
+	SynthesizeOptions_Voice_DeDeDieterv3voice    = "de-DE_DieterV3Voice"
 	SynthesizeOptions_Voice_DeDeDietervoice      = "de-DE_DieterVoice"
+	SynthesizeOptions_Voice_EnGbKatev3voice      = "en-GB_KateV3Voice"
 	SynthesizeOptions_Voice_EnGbKatevoice        = "en-GB_KateVoice"
 	SynthesizeOptions_Voice_EnUsAllisonv2voice   = "en-US_AllisonV2Voice"
+	SynthesizeOptions_Voice_EnUsAllisonv3voice   = "en-US_AllisonV3Voice"
 	SynthesizeOptions_Voice_EnUsAllisonvoice     = "en-US_AllisonVoice"
 	SynthesizeOptions_Voice_EnUsLisav2voice      = "en-US_LisaV2Voice"
+	SynthesizeOptions_Voice_EnUsLisav3voice      = "en-US_LisaV3Voice"
 	SynthesizeOptions_Voice_EnUsLisavoice        = "en-US_LisaVoice"
 	SynthesizeOptions_Voice_EnUsMichaelv2voice   = "en-US_MichaelV2Voice"
+	SynthesizeOptions_Voice_EnUsMichaelv3voice   = "en-US_MichaelV3Voice"
 	SynthesizeOptions_Voice_EnUsMichaelvoice     = "en-US_MichaelVoice"
+	SynthesizeOptions_Voice_EsEsEnriquev3voice   = "es-ES_EnriqueV3Voice"
 	SynthesizeOptions_Voice_EsEsEnriquevoice     = "es-ES_EnriqueVoice"
+	SynthesizeOptions_Voice_EsEsLaurav3voice     = "es-ES_LauraV3Voice"
 	SynthesizeOptions_Voice_EsEsLauravoice       = "es-ES_LauraVoice"
+	SynthesizeOptions_Voice_EsLaSofiav3voice     = "es-LA_SofiaV3Voice"
 	SynthesizeOptions_Voice_EsLaSofiavoice       = "es-LA_SofiaVoice"
+	SynthesizeOptions_Voice_EsUsSofiav3voice     = "es-US_SofiaV3Voice"
 	SynthesizeOptions_Voice_EsUsSofiavoice       = "es-US_SofiaVoice"
+	SynthesizeOptions_Voice_FrFrReneev3voice     = "fr-FR_ReneeV3Voice"
 	SynthesizeOptions_Voice_FrFrReneevoice       = "fr-FR_ReneeVoice"
 	SynthesizeOptions_Voice_ItItFrancescav2voice = "it-IT_FrancescaV2Voice"
+	SynthesizeOptions_Voice_ItItFrancescav3voice = "it-IT_FrancescaV3Voice"
 	SynthesizeOptions_Voice_ItItFrancescavoice   = "it-IT_FrancescaVoice"
 	SynthesizeOptions_Voice_JaJpEmivoice         = "ja-JP_EmiVoice"
+	SynthesizeOptions_Voice_PtBrIsabelav3voice   = "pt-BR_IsabelaV3Voice"
 	SynthesizeOptions_Voice_PtBrIsabelavoice     = "pt-BR_IsabelaVoice"
 )
 
@@ -1696,8 +1721,6 @@ const (
 // The requested format (MIME type) of the audio. You can use the `Accept` header or the `accept` parameter to specify
 // the audio format. For more information about specifying an audio format, see **Audio formats (accept types)** in the
 // method description.
-//
-// Default: `audio/ogg;codecs=opus`.
 const (
 	SynthesizeOptions_Accept_AudioBasic            = "audio/basic"
 	SynthesizeOptions_Accept_AudioFlac             = "audio/flac"
@@ -1794,8 +1817,8 @@ const (
 // UpdateVoiceModelOptions : The UpdateVoiceModel options.
 type UpdateVoiceModelOptions struct {
 
-	// The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-	// for the instance of the service that owns the custom model.
+	// The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance
+	// of the service that owns the custom model.
 	CustomizationID *string `json:"customization_id" validate:"required"`
 
 	// A new name for the custom voice model.
@@ -1892,16 +1915,16 @@ type VoiceModel struct {
 	// The language identifier of the custom voice model (for example, `en-US`).
 	Language *string `json:"language,omitempty"`
 
-	// The GUID of the service credentials for the instance of the service that owns the custom voice model.
+	// The GUID of the credentials for the instance of the service that owns the custom voice model.
 	Owner *string `json:"owner,omitempty"`
 
 	// The date and time in Coordinated Universal Time (UTC) at which the custom voice model was created. The value is
 	// provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
 	Created *string `json:"created,omitempty"`
 
-	// The date and time in Coordinated Universal Time (UTC) at which the custom voice model was last modified. Equals
-	// `created` when a new voice model is first added but has yet to be updated. The value is provided in full ISO 8601
-	// format (`YYYY-MM-DDThh:mm:ss.sTZD`).
+	// The date and time in Coordinated Universal Time (UTC) at which the custom voice model was last modified. The
+	// `created` and `updated` fields are equal when a voice model is first added but has yet to be updated. The value is
+	// provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
 	LastModified *string `json:"last_modified,omitempty"`
 
 	// The description of the custom voice model.
@@ -1918,8 +1941,8 @@ type VoiceModel struct {
 type VoiceModels struct {
 
 	// An array of `VoiceModel` objects that provides information about each available custom voice model. The array is
-	// empty if the requesting service credentials own no custom voice models (if no language is specified) or own no
-	// custom voice models for the specified language.
+	// empty if the requesting credentials own no custom voice models (if no language is specified) or own no custom voice
+	// models for the specified language.
 	Customizations []VoiceModel `json:"customizations" validate:"required"`
 }
 


### PR DESCRIPTION
#### 0.10.0 (https://github.com/watson-developer-cloud/go-sdk/compare/v0.9.0...v0.10.0) (2019-07-24)

### Features

    * assistantv2: DialogRuntimeResponseGeneric has new params Header and []SearchResult (74c6a3d (https://github.com/watson-developer-cloud/go-sdk/commit/74c6a3d))
    * compare comply: Basic auth support (1bec8be (https://github.com/watson-developer-cloud/go-sdk/commit/1bec8be))
    * compare comply: ClassifyReturn has new params ContractTerms, PaymentTerms and ContractTypes (b1d16be (https://github.com/watson-developer-cloud/go-sdk/commit/b1d16be))
    * compare comply: DocStructure has new param Paragraphs (e3c0e9a (https://github.com/watson-developer-cloud/go-sdk/commit/e3c0e9a))
    * compare comply: Model changes to compare comply (fd70e93 (https://github.com/watson-developer-cloud/go-sdk/commit/fd70e93))
    * compare comply: Tables has new param Contexts and KeyValuePairs (74290be (https://github.com/watson-developer-cloud/go-sdk/commit/74290be))
    * compare comply: Tables has new param TableTitle (42899aa (https://github.com/watson-developer-cloud/go-sdk/commit/42899aa))
    * NLU: New param Confidence in EntityMention and EntitiesResult (a0cd859 (https://github.com/watson-developer-cloud/go-sdk/commit/a0cd859))
    * speech to text: New param ProcessingMetrics in SpeechRecognitionResults (9e08650 (https://github.com/watson-developer-cloud/go-sdk/commit/9e08650))
    * speech to text: New param Updated in AcousticModel and LanguageModel (9ba61ad (https://github.com/watson-developer-cloud/go-sdk/commit/9ba61ad))