### PR TITLE
fix: Add dependency on go-sdk-core to Gopkg.toml

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:0f5a0001405e7d59d2786ac0ad796603e8223239ff5d65a0b41fd04253455938"
+  digest = "1:9534ba03bc6069f23db44af1a8042a0c804de6d70d88e99fe983f00a6008d920"
   name = "github.com/IBM/go-sdk-core"
   packages = ["core"]
   pruneopts = "UT"
-  revision = "fec31e02faade6bb13679f3c96e0c7cd94c46f6c"
-  version = "v0.4.1"
+  revision = "8d1e78cf47c48b6d7c9a5010b88d3ed967a7c711"
+  version = "v0.4.2"
 
 [[projects]]
   digest = "1:320e7ead93de9fd2b0e59b50fd92a4d50c1f8ab455d96bc2eb083267453a9709"
@@ -210,6 +210,28 @@
   version = "v1.2.2"
 
 [[projects]]
+  digest = "1:5ce592009bae58e2c1d6ad554123df7986db31212e7a5cfcf52e857894479aa2"
+  name = "github.com/watson-developer-cloud/go-sdk"
+  packages = [
+    "assistantv1",
+    "assistantv2",
+    "common",
+    "comparecomplyv1",
+    "discoveryv1",
+    "languagetranslatorv3",
+    "naturallanguageclassifierv1",
+    "naturallanguageunderstandingv1",
+    "personalityinsightsv3",
+    "speechtotextv1",
+    "texttospeechv1",
+    "toneanalyzerv3",
+    "visualrecognitionv3",
+  ]
+  pruneopts = "UT"
+  revision = "c04fabb62ced8905d2ee066d08757d2c6ff7c4d1"
+  version = "v0.11.0"
+
+[[projects]]
   branch = "master"
   digest = "1:5193d913046443e59093d66a97a40c51f4a5ea4ceba60f3b3ecf89694de5d16f"
   name = "golang.org/x/net"
@@ -298,6 +320,19 @@
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
     "github.com/stretchr/testify/assert",
+    "github.com/watson-developer-cloud/go-sdk/assistantv1",
+    "github.com/watson-developer-cloud/go-sdk/assistantv2",
+    "github.com/watson-developer-cloud/go-sdk/common",
+    "github.com/watson-developer-cloud/go-sdk/comparecomplyv1",
+    "github.com/watson-developer-cloud/go-sdk/discoveryv1",
+    "github.com/watson-developer-cloud/go-sdk/languagetranslatorv3",
+    "github.com/watson-developer-cloud/go-sdk/naturallanguageclassifierv1",
+    "github.com/watson-developer-cloud/go-sdk/naturallanguageunderstandingv1",
+    "github.com/watson-developer-cloud/go-sdk/personalityinsightsv3",
+    "github.com/watson-developer-cloud/go-sdk/speechtotextv1",
+    "github.com/watson-developer-cloud/go-sdk/texttospeechv1",
+    "github.com/watson-developer-cloud/go-sdk/toneanalyzerv3",
+    "github.com/watson-developer-cloud/go-sdk/visualrecognitionv3",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,6 +24,9 @@
 #   go-tests = true
 #   unused-packages = true
 
+[[constraint]]
+  name = "github.com/IBM/go-sdk-core"
+  version = "0.4.2"
 
 [[constraint]]
   name = "github.com/cloudfoundry-community/go-cfenv"


### PR DESCRIPTION
This PR adds a dependency on the go-sdk-core package to Gopkg.toml so that a reliable version of the sdk core is used.
