### PR TITLE
fix(nlu): Add Deprecated param Model back in CategoriesOptions

### DIFF
--- a/naturallanguageunderstandingv1/natural_language_understanding_v1.go
+++ b/naturallanguageunderstandingv1/natural_language_understanding_v1.go
@@ -521,9 +521,14 @@ type CategoriesOptions struct {
 	// Maximum number of categories to return.
 	Limit *int64 `json:"limit,omitempty"`
 
-	// Deprecated: The custom categories experimental feature will be retired on 19 December 2019. On that date,
-	// deployed custom categories models will no longer be accessible in Natural Language Understanding.
-	// The feature will be removed from Knowledge Studio on an earlier date.
+	// Enter a [custom
+	// model](https://cloud.ibm.com/docs/services/natural-language-understanding?topic=natural-language-understanding-customizing)
+	// ID to override the standard categories model.
+	//
+	// The custom categories experimental feature will be retired on 19 December 2019. On that date, deployed custom
+	// categories models will no longer be accessible in Natural Language Understanding. The feature will be removed from
+	// Knowledge Studio on an earlier date. Custom categories models will no longer be accessible in Knowledge Studio on 17
+	// December 2019.
 	Model *string `json:"model,omitempty"`
 }
 

--- a/naturallanguageunderstandingv1/natural_language_understanding_v1.go
+++ b/naturallanguageunderstandingv1/natural_language_understanding_v1.go
@@ -521,9 +521,9 @@ type CategoriesOptions struct {
 	// Maximum number of categories to return.
 	Limit *int64 `json:"limit,omitempty"`
 
-	// Deprecated: Enter a [custom
-	// model](https://cloud.ibm.com/docs/services/natural-language-understanding?topic=natural-language-understanding-customizing)
-	// ID to override the standard categories model.
+	// Deprecated: The custom categories experimental feature will be retired on 19 December 2019. On that date,
+	// deployed custom categories models will no longer be accessible in Natural Language Understanding.
+	// The feature will be removed from Knowledge Studio on an earlier date.
 	Model *string `json:"model,omitempty"`
 }
 

--- a/naturallanguageunderstandingv1/natural_language_understanding_v1.go
+++ b/naturallanguageunderstandingv1/natural_language_understanding_v1.go
@@ -520,6 +520,11 @@ type CategoriesOptions struct {
 
 	// Maximum number of categories to return.
 	Limit *int64 `json:"limit,omitempty"`
+
+	// Deprecated: Enter a [custom
+	// model](https://cloud.ibm.com/docs/services/natural-language-understanding?topic=natural-language-understanding-customizing)
+	// ID to override the standard categories model.
+	Model *string `json:"model,omitempty"`
 }
 
 // CategoriesRelevantText : Relevant text that contributed to the categorization.


### PR DESCRIPTION
This is a patch release which adds the `model` back in `CategoriesOptions` in NLU which was removed from the previous release. Although this is deprecated in the service