### PR TITLE
fix: use go-sdk-core v2.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/watson-developer-cloud/go-sdk
 go 1.12
 
 require (
-	github.com/IBM/go-sdk-core v1.1.1-0.20191204032945-b7e55c23dc56
+	github.com/IBM/go-sdk-core v0.0.0-20200217212347-fe152a0e9e89
 	github.com/go-openapi/strfmt v0.19.3
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/gorilla/websocket v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/IBM/go-sdk-core v1.1.1-0.20191204032945-b7e55c23dc56 h1:WvMEl9BtUPuCgG+k9S53hYXzv7/TYUID7BISUOl10Is=
-github.com/IBM/go-sdk-core v1.1.1-0.20191204032945-b7e55c23dc56/go.mod h1:2pcx9YWsIsZ3I7kH+1amiAkXvLTZtAq9kbxsfXilSoY=
+github.com/IBM/go-sdk-core v0.0.0-20200217212347-fe152a0e9e89 h1:xvNuMMhsiGhHUA7DWob/sM8OFddqDdzOJkpX626cA1I=
+github.com/IBM/go-sdk-core v0.0.0-20200217212347-fe152a0e9e89/go.mod h1:2pcx9YWsIsZ3I7kH+1amiAkXvLTZtAq9kbxsfXilSoY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This PR updates the go core version to 2.1.1 within the go.mod file