### PR TITLE
Update outdated links to docs as redirect will stop in May

### DIFF
--- a/assistantv1/assistant_v1.go
+++ b/assistantv1/assistant_v1.go
@@ -4895,7 +4895,7 @@ type DialogNodeOutputGeneric struct {
 
 	// The text of the search query. This can be either a natural-language query or a query that uses the Discovery query
 	// language syntax, depending on the value of the **query_type** property. For more information, see the [Discovery
-	// service documentation](https://cloud.ibm.com/docs/discovery/query-operators.html#query-operators). Required when
+	// service documentation](https://cloud.ibm.com/docs/discovery?topic=discovery-query-operators#query-operators). Required when
 	// **response_type**=`search_skill`.
 	Query *string `json:"query,omitempty"`
 
@@ -4904,7 +4904,7 @@ type DialogNodeOutputGeneric struct {
 
 	// An optional filter that narrows the set of documents to be searched. For more information, see the [Discovery
 	// service documentation]([Discovery service
-	// documentation](https://cloud.ibm.com/docs/discovery/query-parameters.html#filter).
+	// documentation](https://cloud.ibm.com/docs/discovery?topic=discovery-query-parameters#filter).
 	Filter *string `json:"filter,omitempty"`
 
 	// The version of the Discovery service API to use for the query.

--- a/texttospeechv1/text_to_speech_v1_adapter.go
+++ b/texttospeechv1/text_to_speech_v1_adapter.go
@@ -63,7 +63,7 @@ type SynthesizeUsingWebsocketOptions struct {
 	// Timings specifies that the service is to return word timing information for all strings of the
 	// input text. The service returns the start and end time of each string of the input. Specify words as the lone element
 	// of the array to request word timings. Specify an empty array or omit the parameter to receive no word timings. For
-	// more information, see [Obtaining word timings](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-timing#timing).
+	// more information, see [Obtaining word timings](https://cloud.ibm.com/docs/text-to-speech?topic=text-to-speech-timing#timing).
 	// Not supported for Japanese input text.
 	Timings []string `json:"action,omitempty"`
 }


### PR DESCRIPTION
### Summary
This pull request updates outdated links in documentation. Current redirects for these links will stop in May. This change has been made in the API definition.