### PR TITLE
docs(global transaction id): add example that shows how to set global…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Go client library to quickly get started with the various [Watson APIs](https://
 * [Configuring the HTTP Client](#configuring-the-http-client)
 * [Disable SSL certificate verification](#disable-ssl-certificate-verification)
 * [Set Service URL](#set-service-url)
-* [Getting the transaction ID](#getting-the-transaction-id)
+* [Using the global transaction ID header](#using-the-global-transaction-id)
 * [IBM Cloud Pak for Data(ICP4D)](#ibm-cloud-pak-for-data(icp4d))
 * [Examples](#examples)
 * [Tests](#tests)
@@ -309,7 +309,7 @@ Or can set it from external sources. For example, environment variables:
 export <YOUR SERVICE NAME>_URL="my new url"
 ```
 
-## Getting the transaction ID
+## Using the global transaction ID
 Every SDK call returns a response with a transaction ID in the x-global-transaction-id header. This transaction ID is useful for troubleshooting and accessing relevant logs from your service instance.
 
 ```go
@@ -317,6 +317,18 @@ result, response, responseErr := service.MyServiceCall(myServiceOptions)
 fmt.Println(response.GetHeaders().Get("X-Global-Transaction-Id"))
 ```
 
+Additionally, you can set a custom `X-Global-Transaction-Id` header in your request. This can make it useful if you need to provide a transaction ID to IBM support to help troubleshoot an issue.
+
+```go
+service, err = assistantv1.NewAssistantV1(&assistantv1.AssistantV1Options{
+	Version:     "2020-04-01",
+	ServiceName: "assistant",
+})
+
+customHeaders := http.Header{}
+customHeaders.Add("X-Global-Transaction-Id", "my-custom-value")
+service.Service.SetDefaultHeaders(customHeaders)
+```
 
 ## Cloud Pak for Data(CP4D)
 If your service instance is of ICP4D, below are two ways of initializing the assistant service.


### PR DESCRIPTION
### Summary

This PR adds an example to the readme that shows how to set the `X-Global-Transaction-Id` header. This is used in situations where someone needs to set a custom value to provide to IBM support or for debugging.