### PR TITLE
Update gateway url to onecloud url [skip ci]

### DIFF
--- a/examples/visualrecognitionv4/visual_recognition_v4.go
+++ b/examples/visualrecognitionv4/visual_recognition_v4.go
@@ -21,7 +21,7 @@ func main() {
 	if serviceErr != nil {
 		panic(serviceErr)
 	}
-	service.SetServiceURL("https://gateway.watsonplatform.net/visual-recognition/api")
+	service.SetServiceURL("https://api.us-south.visual-recognition.watson.cloud.ibm.com")
 
 	/* CREATE COLLLECTION */
 	collection, _, responseErr := service.CreateCollection(


### PR DESCRIPTION
### Summary
Watsonplatform.net urls will cease to function after Feb 12, 2021. This pull request updates references of the url with the corresponding onecloud url.