### PR TITLE
fix(bumpversion): correct path for the common module

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ current_version = 2.0.1
 commit = True
 message = [skip ci] docs: Update version numbers from {current_version} -> {new_version}
 
-[bumpversion:file:common/version.go]
+[bumpversion:file:v2/common/version.go]
 search = Version = "{current_version}"
 replace = Version = "{new_version}"
 


### PR DESCRIPTION
### Summary

This corrects the path to `v2/common/version.go` in bumpversion. I forgot this in the previous PR which caused the release to fail.